### PR TITLE
feat: add BMAD Beta compatibility and path support

### DIFF
--- a/.bmad-assist/patches/code-review.patch.yaml
+++ b/.bmad-assist/patches/code-review.patch.yaml
@@ -5,7 +5,7 @@ patch:
   description: "Optimizes code-review workflow for Multi-LLM automation - removes interactive steps, produces code review report to stdout only"
 
 compatibility:
-  bmad_version: "6.0.0-alpha.22"
+  bmad_version: ">=6.0.0-alpha.22"
   workflow: "code-review"
   # NOTE: This patch is compatible with the 5-step code-review workflow
   # Steps: 1 (file discovery), 2 (attack plan), 3 (adversarial review),

--- a/.bmad-assist/patches/create-story.patch.yaml
+++ b/.bmad-assist/patches/create-story.patch.yaml
@@ -5,7 +5,7 @@ patch:
   description: "Optimizes create-story workflow - removes programmatically handled steps, embeds all context"
 
 compatibility:
-  bmad_version: "6.0.0-alpha.22"
+  bmad_version: ">=6.0.0-alpha.22"
   workflow: "create-story"
 
 git_intelligence:

--- a/.bmad-assist/patches/dev-story.patch.yaml
+++ b/.bmad-assist/patches/dev-story.patch.yaml
@@ -14,7 +14,7 @@ patch:
   description: "Removes interactivity from dev-story for bmad-assist automation - Master LLM implements story with READ+WRITE permission"
 
 compatibility:
-  bmad_version: "6.0.0-alpha.22"
+  bmad_version: ">=6.0.0-alpha.22"
   workflow: "dev-story"
   # NOTE: dev-story has 10 steps in instructions.xml
   # Steps 1, 4, 10 are removed (discovery, sprint-status, user comms)

--- a/.bmad-assist/patches/qa-plan-execute.patch.yaml
+++ b/.bmad-assist/patches/qa-plan-execute.patch.yaml
@@ -5,7 +5,7 @@ patch:
   description: "Strip interactivity for automated/CI execution"
 
 compatibility:
-  bmad_version: "6.0.0-alpha.22"
+  bmad_version: ">=6.0.0-alpha.22"
   workflow: "qa-plan-execute"
 
 # Conditions for patch application

--- a/.bmad-assist/patches/qa-plan-generate.patch.yaml
+++ b/.bmad-assist/patches/qa-plan-generate.patch.yaml
@@ -5,7 +5,7 @@ patch:
   description: "Enhance QA plan generation with strict selector usage and project context"
 
 compatibility:
-  bmad_version: "6.0.0-alpha.22"
+  bmad_version: ">=6.0.0-alpha.22"
   workflow: "qa-plan-generate"
 
 # No transforms needed - CRITICAL Output Requirements are in instructions.md

--- a/.bmad-assist/patches/retrospective.patch.yaml
+++ b/.bmad-assist/patches/retrospective.patch.yaml
@@ -9,7 +9,7 @@ patch:
   description: "Transforms retrospective from interactive party-mode to automated single-output workflow with extraction markers"
 
 compatibility:
-  bmad_version: "6.0.0-alpha.22"
+  bmad_version: ">=6.0.0-alpha.22"
   workflow: "retrospective"
 
 transforms:

--- a/.bmad-assist/patches/validate-story.patch.yaml
+++ b/.bmad-assist/patches/validate-story.patch.yaml
@@ -5,7 +5,7 @@ patch:
   description: "Optimizes validate-story workflow for bmad-assist Multi-LLM automation - removes interactive steps, produces validation report only"
 
 compatibility:
-  bmad_version: "6.0.0-alpha.22"
+  bmad_version: ">=6.0.0-alpha.22"
   workflow: "validate-story"
   # NOTE: This patch transforms the interactive Master-LLM workflow into a read-only Multi-LLM validator
   # Workflow has 10 steps, patch reduces to 5 (removes file discovery + user interaction + file modification)

--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,8 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 MagicMock/
+
+# bmad-assist artifacts (auto-generated, never commit)
+.bmad-assist/cache/
+*.meta.yaml
+*.tpl.xml

--- a/src/bmad_assist/bmad/correction.py
+++ b/src/bmad_assist/bmad/correction.py
@@ -66,6 +66,10 @@ def _get_sprint_status_path(bmad_root: Path) -> Path:
         return paths.sprint_status_file
     except RuntimeError:
         # Fallback when singleton not initialized
+        # Check planning-artifacts first (Beta default), then legacy locations
+        planning_artifacts = bmad_root.parent / "_bmad-output" / "planning-artifacts" / "sprint-status.yaml"
+        if planning_artifacts.exists():
+            return planning_artifacts
         legacy_artifacts = bmad_root / "sprint-artifacts" / "sprint-status.yaml"
         if legacy_artifacts.exists():
             return legacy_artifacts

--- a/src/bmad_assist/bmad/state_reader.py
+++ b/src/bmad_assist/bmad/state_reader.py
@@ -58,6 +58,7 @@ def _get_sprint_status_candidates(bmad_path: Path) -> list[Path]:
         return [
             # New location
             project_root / "_bmad-output" / "implementation-artifacts" / "sprint-status.yaml",
+            project_root / "_bmad-output" / "planning-artifacts" / "sprint-status.yaml",  # Beta default
             bmad_path / "sprint-artifacts" / "sprint-status.yaml",  # Legacy
             bmad_path / "sprint-status.yaml",  # Legacy (direct)
         ]

--- a/src/bmad_assist/compiler/patching/compiler.py
+++ b/src/bmad_assist/compiler/patching/compiler.py
@@ -40,8 +40,17 @@ _WORKFLOW_LOCATIONS = [
     "_bmad/bmm/workflows/4-implementation",  # Implementation workflows
     "_bmad/bmm/workflows/testarch",  # TEA workflows
     "_bmad/bmm/workflows/3-solutioning",  # Solutioning workflows
+    "_bmad/bmm/workflows/testarch",  # Testarch module
+    "_bmad/bmm/workflows/qa",  # QA module (Beta)
     "_bmad/bmm/workflows",  # Generic workflows
     "_bmad/core/workflows",  # Core workflows
+    "_bmad/tea/workflows/testarch",  # TEA external module
+    "_bmad/sdet/workflows",  # SDET module
+    # Legacy structure (.bmad/)
+    ".bmad/bmm/workflows/4-implementation",  # Implementation workflows
+    ".bmad/bmm/workflows/3-solutioning",  # Solutioning workflows
+    ".bmad/bmm/workflows",  # Generic workflows
+    ".bmad/core/workflows",  # Core workflows
 ]
 
 # Mapping from workflow name to BMAD directory structure

--- a/src/bmad_assist/compiler/shared_utils.py
+++ b/src/bmad_assist/compiler/shared_utils.py
@@ -560,6 +560,7 @@ def find_sprint_status_file(context: CompilerContext) -> Path | None:
     # Fallback locations
     candidates.extend(
         [
+            context.output_folder / "planning-artifacts" / "sprint-status.yaml",  # Beta default
             context.output_folder / "sprint-artifacts" / "sprint-status.yaml",
             context.output_folder / "sprint-status.yaml",
         ]
@@ -600,6 +601,14 @@ def find_project_context_file(context: CompilerContext) -> Path | None:
         context.output_folder / "project-context.md",
         context.output_folder / "project_context.md",
     ])
+
+    # Priority 2b: Parent of output folder (e.g., _bmad-output/ when output_folder is implementation-artifacts/)
+    output_parent = context.output_folder.parent
+    if output_parent != context.project_root:
+        candidates.extend([
+            output_parent / "project-context.md",
+            output_parent / "project_context.md",
+        ])
 
     # Priority 3: Local docs folder (if not using external project_knowledge)
     if context.project_knowledge is None:

--- a/src/bmad_assist/compiler/variables/sprint_status.py
+++ b/src/bmad_assist/compiler/variables/sprint_status.py
@@ -61,6 +61,7 @@ def _resolve_sprint_status(
     # Legacy fallback for compiler-only usage (check multiple locations)
     fallback_locations = [
         context.project_root / "_bmad-output" / "implementation-artifacts" / "sprint-status.yaml",
+        context.project_root / "_bmad-output" / "planning-artifacts" / "sprint-status.yaml",  # Beta default
         context.project_root / "docs" / "sprint-status.yaml",
         context.project_root / "docs" / "sprint-artifacts" / "sprint-status.yaml",
     ]

--- a/src/bmad_assist/compiler/workflow_discovery.py
+++ b/src/bmad_assist/compiler/workflow_discovery.py
@@ -37,6 +37,8 @@ STANDARD_WORKFLOWS = {
     "testarch-framework",
     "testarch-nfr-assess",
     "testarch-test-design",
+    # QA module (Beta)
+    "qa-automate",
 }
 
 # Search locations for user's BMAD installation (checked in order)
@@ -44,6 +46,9 @@ STANDARD_WORKFLOWS = {
 BMAD_SEARCH_PATHS = [
     "_bmad/bmm/workflows/4-implementation",
     "_bmad/bmm/workflows/testarch",
+    "_bmad/bmm/workflows/qa",              # Beta QA automate (SDET)
+    "_bmad/tea/workflows/testarch",        # TEA external module
+    "_bmad/sdet/workflows",                # Future SDET module
 ]
 
 # Mapping from workflow name to BMAD directory structure
@@ -57,6 +62,7 @@ WORKFLOW_TO_BMAD_DIR = {
     "testarch-framework": "framework",
     "testarch-nfr-assess": "nfr-assess",
     "testarch-test-design": "test-design",
+    "qa-automate": "automate",  # Beta QA automate workflow
 }
 
 

--- a/src/bmad_assist/core/loop/handlers/base.py
+++ b/src/bmad_assist/core/loop/handlers/base.py
@@ -36,7 +36,7 @@ from bmad_assist.core.config.models.providers import (
     MultiProviderConfig,
     get_phase_provider_config,
 )
-from bmad_assist.core.exceptions import ConfigError, ProviderExitCodeError
+from bmad_assist.core.exceptions import CompilerError, ConfigError, ProviderExitCodeError
 from bmad_assist.core.io import get_original_cwd
 from bmad_assist.core.loop.types import PhaseResult
 from bmad_assist.core.paths import get_paths

--- a/src/bmad_assist/core/paths.py
+++ b/src/bmad_assist/core/paths.py
@@ -315,6 +315,7 @@ class ProjectPaths:
         """
         candidates = [
             self.sprint_status_file,  # New: implementation-artifacts/
+            self.planning_artifacts / "sprint-status.yaml",  # Beta default
             self.legacy_sprint_artifacts / "sprint-status.yaml",  # Legacy
             self.project_knowledge / "sprint-status.yaml",  # Legacy (direct)
         ]

--- a/src/bmad_assist/dashboard/server.py
+++ b/src/bmad_assist/dashboard/server.py
@@ -941,8 +941,8 @@ class DashboardServer:
 
             result["epics"].append(epic_data)
 
-        # Sort epics by id
-        result["epics"].sort(key=lambda e: (int(e["id"]) if str(e["id"]).isdigit() else e["id"]))
+        # Sort epics by id (numeric first, then string)
+        result["epics"].sort(key=lambda e: (0, int(e["id"])) if str(e["id"]).isdigit() else (1, str(e["id"])))
 
         return result
 

--- a/src/bmad_assist/default_patches/code-review.patch.yaml
+++ b/src/bmad_assist/default_patches/code-review.patch.yaml
@@ -5,7 +5,7 @@ patch:
   description: "Optimizes code-review workflow for Multi-LLM automation - removes interactive steps, produces code review report to stdout only"
 
 compatibility:
-  bmad_version: "6.0.0-alpha.22"
+  bmad_version: ">=6.0.0-alpha.22"
   workflow: "code-review"
   # NOTE: This patch is compatible with the 6-step code-review workflow (customized with Evidence Score)
   # Steps: 1 (file discovery), 2 (attack plan), 3 (adversarial review),

--- a/src/bmad_assist/default_patches/create-story.patch.yaml
+++ b/src/bmad_assist/default_patches/create-story.patch.yaml
@@ -5,7 +5,7 @@ patch:
   description: "Optimizes create-story workflow - removes programmatically handled steps, embeds all context"
 
 compatibility:
-  bmad_version: "6.0.0-alpha.22"
+  bmad_version: ">=6.0.0-alpha.22"
   workflow: "create-story"
 
 git_intelligence:

--- a/src/bmad_assist/default_patches/dev-story.patch.yaml
+++ b/src/bmad_assist/default_patches/dev-story.patch.yaml
@@ -14,7 +14,7 @@ patch:
   description: "Removes interactivity from dev-story for bmad-assist automation - Master LLM implements story with READ+WRITE permission"
 
 compatibility:
-  bmad_version: "6.0.0-alpha.22"
+  bmad_version: ">=6.0.0-alpha.22"
   workflow: "dev-story"
   # NOTE: dev-story has 10 steps in instructions.xml
   # Steps 1, 4, 10 are removed (discovery, sprint-status, user comms)

--- a/src/bmad_assist/default_patches/qa-plan-execute.patch.yaml
+++ b/src/bmad_assist/default_patches/qa-plan-execute.patch.yaml
@@ -5,7 +5,7 @@ patch:
   description: "Strip interactivity for automated/CI execution"
 
 compatibility:
-  bmad_version: "6.0.0-alpha.22"
+  bmad_version: ">=6.0.0-alpha.22"
   workflow: "qa-plan-execute"
 
 # Conditions for patch application

--- a/src/bmad_assist/default_patches/qa-plan-generate.patch.yaml
+++ b/src/bmad_assist/default_patches/qa-plan-generate.patch.yaml
@@ -5,7 +5,7 @@ patch:
   description: "Enhance QA plan generation with strict selector usage and project context"
 
 compatibility:
-  bmad_version: "6.0.0-alpha.22"
+  bmad_version: ">=6.0.0-alpha.22"
   workflow: "qa-plan-generate"
 
 # No transforms needed - CRITICAL Output Requirements are in instructions.md

--- a/src/bmad_assist/default_patches/retrospective.patch.yaml
+++ b/src/bmad_assist/default_patches/retrospective.patch.yaml
@@ -9,7 +9,7 @@ patch:
   description: "Transforms retrospective from interactive party-mode to automated single-output workflow with extraction markers"
 
 compatibility:
-  bmad_version: "6.0.0-alpha.22"
+  bmad_version: ">=6.0.0-alpha.22"
   workflow: "retrospective"
 
 transforms:

--- a/src/bmad_assist/default_patches/validate-story.patch.yaml
+++ b/src/bmad_assist/default_patches/validate-story.patch.yaml
@@ -5,7 +5,7 @@ patch:
   description: "Optimizes validate-story workflow for bmad-assist Multi-LLM automation - removes interactive steps, produces validation report only"
 
 compatibility:
-  bmad_version: "6.0.0-alpha.22"
+  bmad_version: ">=6.0.0-alpha.22"
   workflow: "validate-story"
   # NOTE: This patch transforms the interactive Master-LLM workflow into a read-only Multi-LLM validator
   # Workflow has 10 steps, patch reduces to 5 (removes file discovery + user interaction + file modification)


### PR DESCRIPTION
Updates bmad-assist to support BMAD v6 Beta and future versions.

Patch Compatibility:
- Change bmad_version from exact "6.0.0-alpha.22" to range ">=6.0.0-alpha.22"
- Allows patches to work with beta and future BMAD versions

Beta Path Support:
- Add planning-artifacts/sprint-status.yaml as Beta default location
- Add project-context.md discovery in output folder parent
- Support TEA, SDET, and QA module workflow paths

New Workflows:
- Add qa-automate workflow (Beta QA/SDET module)
- Add testarch workflow paths for TEA external module

Error Handling:
- CompilerError now re-raises instead of silently falling back to YAML
- Better distinction between "compiler not available" vs "compiler error"

Dashboard:
- Fix epic sorting to handle both numeric and string IDs (e.g., "testarch")

Gitignore:
- Add bmad-assist cache artifacts (.bmad-assist/cache/, *.meta.yaml, *.tpl.xml)