### PR TITLE
fix: use setdefault for language variables to preserve config.yaml values

### DIFF
--- a/src/bmad_assist/compiler/variables/core.py
+++ b/src/bmad_assist/compiler/variables/core.py
@@ -252,7 +252,7 @@ def resolve_variables(
     7. project_context resolution (dual-name detection with token estimate)
     8. input_file_patterns resolution (directory-based - overrides earlier)
     9. sprint_status resolution (docs/ or docs/sprint-artifacts/)
-    10. Hard overrides (user_skill_level, communication_language, etc.)
+    10. Overrides & defaults (user_skill_level hard; language defaults soft)
     11. Remove internal/unused variables
 
     Args:
@@ -416,10 +416,12 @@ def resolve_variables(
                 resolved[key] = value
                 logger.debug("Set from TEA resolver: %s", key)
 
-    # Step 10: Apply hard overrides (always enforced regardless of config)
+    # Step 10: Apply overrides and defaults
+    # - user_skill_level: hard override (always enforced)
+    # - communication_language, document_output_language: soft defaults (config.yaml wins)
     resolved["user_skill_level"] = "expert"
-    resolved["communication_language"] = "English"
-    resolved["document_output_language"] = "English"
+    resolved.setdefault("communication_language", "English")
+    resolved.setdefault("document_output_language", "English")
 
     # Step 11: Remove internal/unused variables
     # - standalone: unused workflow flag, conflicts with future "standalone story" feature


### PR DESCRIPTION
## Summary

- `communication_language` and `document_output_language` were hard-overridden to `"English"` in Step 10 of variable resolution, ignoring any value set in `config.yaml`
- Changed `resolved["communication_language"] = "English"` → `resolved.setdefault("communication_language", "English")` (same for `document_output_language`)
- Now if `config.yaml` defines e.g. `communication_language: French`, the value is preserved; `"English"` is only used as a fallback

## Test plan

- [ ] Existing tests pass (they all set `English` in fixtures, so `setdefault` produces the same result)
- [ ] Manually verify with a `config.yaml` that sets `communication_language: French` — the value should now be preserved
