### PR TITLE
fix: use bypassPermissions for full tool access in automated workflows

### DIFF
--- a/src/bmad_assist/providers/claude_sdk.py
+++ b/src/bmad_assist/providers/claude_sdk.py
@@ -308,7 +308,7 @@ class ClaudeSDKProvider(BaseProvider):
         # Build SDK options with explicit values
         options = ClaudeAgentOptions(
             model=model,
-            permission_mode="acceptEdits",  # Explicit automation mode
+            permission_mode="bypassPermissions",  # Full tool access for automated workflows (Bash, Edit, etc.)
             settings=str(settings) if settings is not None else None,
             cwd=cwd,
             cli_path=cli_path,  # None = SDK default (bundled → system)


### PR DESCRIPTION
## Summary
- Switch Claude SDK permission_mode from `acceptEdits` to `bypassPermissions` to enable full tool access (Bash, Edit, etc.) in automated workflows

## Test plan
- [ ] Verify automated Claude SDK workflows can invoke Bash and Edit tools without permission prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)