### PR TITLE
feat: dismissed findings tracking for code reviews

### DIFF
--- a/src/bmad_assist/antipatterns/__init__.py
+++ b/src/bmad_assist/antipatterns/__init__.py
@@ -22,6 +22,11 @@ Usage:
     )
 """
 
+from bmad_assist.antipatterns.dismissed_extractor import (
+    append_to_dismissed_findings_file,
+    extract_and_append_dismissed_findings,
+    extract_dismissed_findings,
+)
 from bmad_assist.antipatterns.extractor import (
     append_to_antipatterns_file,
     extract_and_append_antipatterns,
@@ -32,4 +37,7 @@ __all__ = [
     "extract_antipatterns",
     "append_to_antipatterns_file",
     "extract_and_append_antipatterns",
+    "extract_dismissed_findings",
+    "append_to_dismissed_findings_file",
+    "extract_and_append_dismissed_findings",
 ]

--- a/src/bmad_assist/antipatterns/dismissed_extractor.py
+++ b/src/bmad_assist/antipatterns/dismissed_extractor.py
@@ -1,0 +1,209 @@
+"""Dismissed findings extraction from synthesis reports.
+
+This module extracts dismissed findings (false positives, intentional design decisions)
+from synthesis reports and persists them for injection into subsequent code review prompts.
+This prevents reviewers from re-flagging issues that have already been investigated and dismissed.
+
+Public API:
+    extract_dismissed_findings: Extract dismissed findings from synthesis content
+    append_to_dismissed_findings_file: Append findings to epic-scoped file
+    extract_and_append_dismissed_findings: Combined convenience function
+"""
+
+import logging
+import re
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from bmad_assist.core.io import atomic_write
+from bmad_assist.core.paths import get_paths
+
+if TYPE_CHECKING:
+    from bmad_assist.core.config import Config
+    from bmad_assist.core.types import EpicId
+
+logger = logging.getLogger(__name__)
+
+# Regex patterns for dismissed findings format
+# Matches "## Issues Dismissed" section up to next ## header or end of content
+DISMISSED_SECTION_PATTERN = re.compile(
+    r"## Issues Dismissed\s*\n(.*?)(?=\n## |\Z)",
+    re.DOTALL,
+)
+
+# Matches individual dismissed items in pipe-delimited format:
+# - **Claimed Issue**: desc | **Raised by**: reviewers | **Dismissal Reason**: reason
+DISMISSED_ITEM_PATTERN = re.compile(
+    r"-\s*\*\*Claimed Issue\*\*:\s*(.+?)\s*\|\s*\*\*Raised by\*\*:\s*(.+?)\s*\|\s*\*\*Dismissal Reason\*\*:\s*(.+?)(?=\n-\s*\*\*Claimed Issue\*\*|\Z)",
+    re.DOTALL,
+)
+
+DISMISSED_FINDINGS_HEADER = """# Epic {epic_id} - Dismissed Findings
+
+> CONTEXT FOR REVIEWERS: These findings were previously investigated during
+> code review synthesis and dismissed with documented reasoning. Do NOT
+> re-flag these issues unless you have substantial NEW evidence that
+> contradicts the dismissal reason.
+
+"""
+
+
+def _clean_text(text: str) -> str:
+    """Clean up extracted text, collapsing whitespace and stripping."""
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def extract_dismissed_findings(
+    synthesis_content: str,
+    epic_id: "EpicId",
+    story_id: str,
+    config: "Config",
+) -> list[dict[str, str]]:
+    """Extract dismissed findings from synthesis content.
+
+    Args:
+        synthesis_content: Raw synthesis report content.
+        epic_id: Epic identifier.
+        story_id: Story identifier (e.g., "5-1").
+        config: Application configuration.
+
+    Returns:
+        List of dicts with keys: claimed_issue, raised_by, dismissal_reason.
+        Returns empty list on any failure (best-effort, non-blocking).
+
+    """
+    logger.info("Starting dismissed findings extraction for story %s", story_id)
+
+    # Check config (reuse antipatterns.enabled flag)
+    try:
+        if not config.antipatterns.enabled:
+            logger.debug("Antipatterns/dismissed extraction disabled in config")
+            return []
+    except AttributeError:
+        pass  # Config doesn't have antipatterns yet, proceed with default enabled
+
+    if not synthesis_content or not synthesis_content.strip():
+        logger.debug("Empty synthesis content, skipping dismissed findings extraction")
+        return []
+
+    # Find Issues Dismissed section
+    section_match = DISMISSED_SECTION_PATTERN.search(synthesis_content)
+    if not section_match:
+        logger.debug("No 'Issues Dismissed' section found, skipping extraction")
+        return []
+
+    section_content = section_match.group(1)
+
+    # Skip if section says "No false positives identified" or similar
+    if re.search(r"no false positives|none identified|no issues dismissed", section_content, re.IGNORECASE):
+        logger.debug("Issues Dismissed section indicates no dismissals")
+        return []
+
+    findings: list[dict[str, str]] = []
+
+    for match in DISMISSED_ITEM_PATTERN.finditer(section_content):
+        claimed_issue = _clean_text(match.group(1))
+        raised_by = _clean_text(match.group(2))
+        dismissal_reason = _clean_text(match.group(3))
+
+        if claimed_issue and dismissal_reason:
+            findings.append(
+                {
+                    "claimed_issue": claimed_issue,
+                    "raised_by": raised_by,
+                    "dismissal_reason": dismissal_reason,
+                }
+            )
+
+    logger.info(
+        "Extracted %d dismissed findings from story %s (epic %s)",
+        len(findings),
+        story_id,
+        epic_id,
+    )
+    return findings
+
+
+def append_to_dismissed_findings_file(
+    findings: list[dict[str, str]],
+    epic_id: "EpicId",
+    story_id: str,
+    project_path: Path,
+) -> None:
+    """Append dismissed findings to epic-scoped file.
+
+    Creates file with header if it doesn't exist.
+    Appends story section with findings table in markdown format.
+
+    File: impl_artifacts/dismissed-findings/epic-{N}-dismissed-findings.md
+
+    Args:
+        findings: List of finding dicts to append.
+        epic_id: Epic identifier.
+        story_id: Story identifier (e.g., "5-1").
+        project_path: Project root path for path resolution.
+
+    """
+    if not findings:
+        logger.debug("No dismissed findings to append, skipping file write")
+        return
+
+    try:
+        paths = get_paths()
+        impl_artifacts = paths.implementation_artifacts
+    except RuntimeError:
+        impl_artifacts = project_path / "_bmad-output" / "implementation-artifacts"
+
+    # Create dismissed-findings subdirectory
+    dismissed_dir = impl_artifacts / "dismissed-findings"
+    dismissed_dir.mkdir(parents=True, exist_ok=True)
+    dismissed_path = dismissed_dir / f"epic-{epic_id}-dismissed-findings.md"
+
+    # Read existing content or start with header
+    if dismissed_path.exists():
+        existing_content = dismissed_path.read_text(encoding="utf-8")
+    else:
+        existing_content = DISMISSED_FINDINGS_HEADER.format(epic_id=epic_id)
+
+    # Build story section with findings table
+    date_str = datetime.now(UTC).strftime("%Y-%m-%d")
+    story_section = f"\n## Story {story_id} ({date_str})\n\n"
+    story_section += "| Finding | Raised By | Dismissal Reason |\n"
+    story_section += "|---------|-----------|------------------|\n"
+
+    for finding in findings:
+        claimed = finding.get("claimed_issue", "").replace("|", "\\|").replace("\n", " ")
+        raised = finding.get("raised_by", "").replace("|", "\\|").replace("\n", " ")
+        reason = finding.get("dismissal_reason", "").replace("|", "\\|").replace("\n", " ")
+        story_section += f"| {claimed} | {raised} | {reason} |\n"
+
+    full_content = existing_content.rstrip() + "\n" + story_section
+
+    atomic_write(dismissed_path, full_content)
+    logger.info("Appended %d dismissed findings to %s", len(findings), dismissed_path)
+
+
+def extract_and_append_dismissed_findings(
+    synthesis_content: str,
+    epic_id: "EpicId",
+    story_id: str,
+    project_path: Path,
+    config: "Config",
+) -> None:
+    """Extract dismissed findings and append to file (convenience function).
+
+    Combines extract_dismissed_findings() and append_to_dismissed_findings_file()
+    into a single call. Handles all errors gracefully (best-effort, non-blocking).
+
+    Args:
+        synthesis_content: Raw synthesis report content.
+        epic_id: Epic identifier.
+        story_id: Story identifier (e.g., "5-1").
+        project_path: Project root path for path resolution.
+        config: Application configuration.
+
+    """
+    findings = extract_dismissed_findings(synthesis_content, epic_id, story_id, config)
+    if findings:
+        append_to_dismissed_findings_file(findings, epic_id, story_id, project_path)

--- a/src/bmad_assist/compiler/strategic_context.py
+++ b/src/bmad_assist/compiler/strategic_context.py
@@ -754,3 +754,62 @@ def load_antipatterns(
     except (OSError, UnicodeDecodeError) as e:
         logger.warning("Failed to read antipatterns: %s", e)
         return {}
+
+
+def load_dismissed_findings(
+    context: CompilerContext,
+) -> dict[str, str]:
+    """Load epic-scoped dismissed findings file for code review context.
+
+    Dismissed findings are previously investigated false positives and
+    intentional design decisions. Injecting them prevents reviewers from
+    re-flagging the same issues across rounds.
+
+    Args:
+        context: Compiler context with resolved variables.
+
+    Returns:
+        Dict with key "[DISMISSED FINDINGS - DO NOT RE-FLAG WITHOUT NEW EVIDENCE]"
+        and content, or empty dict if disabled/missing.
+
+    """
+    # Check config (reuse antipatterns.enabled flag)
+    try:
+        from bmad_assist.core.config import get_config
+
+        if not get_config().antipatterns.enabled:
+            logger.debug("Dismissed findings loading disabled in config")
+            return {}
+    except (ImportError, AttributeError, RuntimeError):
+        pass  # Config not available, proceed with default enabled
+
+    # Get epic_id
+    epic_id = context.resolved_variables.get("epic_num")
+    if not epic_id:
+        logger.debug("No epic_num in context, skipping dismissed findings")
+        return {}
+
+    # Build path
+    try:
+        from bmad_assist.core.paths import get_paths
+
+        paths = get_paths()
+        impl_artifacts = paths.implementation_artifacts
+    except RuntimeError:
+        impl_artifacts = context.project_root / "_bmad-output" / "implementation-artifacts"
+
+    dismissed_path = impl_artifacts / "dismissed-findings" / f"epic-{epic_id}-dismissed-findings.md"
+
+    if not dismissed_path.exists():
+        logger.debug("No dismissed findings file for epic %s", epic_id)
+        return {}
+
+    try:
+        content = dismissed_path.read_text(encoding="utf-8")
+        logger.info(
+            "Loaded dismissed findings for epic %s (%d chars)", epic_id, len(content)
+        )
+        return {"[DISMISSED FINDINGS - DO NOT RE-FLAG WITHOUT NEW EVIDENCE]": content}
+    except (OSError, UnicodeDecodeError) as e:
+        logger.warning("Failed to read dismissed findings: %s", e)
+        return {}

--- a/src/bmad_assist/compiler/workflows/code_review.py
+++ b/src/bmad_assist/compiler/workflows/code_review.py
@@ -523,7 +523,10 @@ class CodeReviewCompiler:
         files.update(strategic_files)
 
         # 1b. Include code antipatterns - reviewers should know what mistakes to look for
-        from bmad_assist.compiler.strategic_context import load_antipatterns, load_dismissed_findings
+        from bmad_assist.compiler.strategic_context import (
+            load_antipatterns,
+            load_dismissed_findings,
+        )
 
         files.update(load_antipatterns(context, "code"))
 

--- a/src/bmad_assist/compiler/workflows/code_review.py
+++ b/src/bmad_assist/compiler/workflows/code_review.py
@@ -523,11 +523,14 @@ class CodeReviewCompiler:
         files.update(strategic_files)
 
         # 1b. Include code antipatterns - reviewers should know what mistakes to look for
-        from bmad_assist.compiler.strategic_context import load_antipatterns
+        from bmad_assist.compiler.strategic_context import load_antipatterns, load_dismissed_findings
 
         files.update(load_antipatterns(context, "code"))
 
-        # 1c. TEA Context (test-design) for reviewing against test plan
+        # 1c. Include dismissed findings - prevent re-flagging false positives
+        files.update(load_dismissed_findings(context))
+
+        # 1d. TEA Context (test-design) for reviewing against test plan
         files.update(collect_tea_context(context, "code_review", resolved))
 
         # 2. Git diff (embedded as virtual file, not in variables)

--- a/src/bmad_assist/core/loop/handlers/code_review_synthesis.py
+++ b/src/bmad_assist/core/loop/handlers/code_review_synthesis.py
@@ -742,6 +742,20 @@ class CodeReviewSynthesisHandler(BaseHandler):
                 except Exception as e:
                     logger.warning("Antipatterns extraction failed (non-blocking): %s", e)
 
+                # Extract dismissed findings for code review context (best-effort, non-blocking)
+                try:
+                    from bmad_assist.antipatterns import extract_and_append_dismissed_findings
+
+                    extract_and_append_dismissed_findings(
+                        synthesis_content=extracted_synthesis,
+                        epic_id=epic_num,
+                        story_id=f"{epic_num}-{story_num}",
+                        project_path=self.project_path,
+                        config=self.config,
+                    )
+                except Exception as e:
+                    logger.warning("Dismissed findings extraction failed (non-blocking): %s", e)
+
                 # Story 13.10: Extract metrics and save synthesizer record
                 # Estimate tokens from char count (~4 chars per token)
                 estimated_output_tokens = len(result.stdout) // 4 if result.stdout else 0

--- a/src/bmad_assist/workflows/code-review/instructions.xml
+++ b/src/bmad_assist/workflows/code-review/instructions.xml
@@ -40,6 +40,17 @@
     <action>Load {project_context} for coding standards (if exists)</action>
   </step>
 
+  <step n="1.5" goal="Check previously dismissed findings">
+    <critical>Before raising any finding, check the DISMISSED FINDINGS context section</critical>
+    <action>If provided, read the [DISMISSED FINDINGS] section carefully</action>
+    <action>For each finding you plan to raise, check if it matches a previously dismissed finding</action>
+    <action>If your finding matches a dismissal:
+      - Only re-flag if you have NEW EVIDENCE that contradicts the documented dismissal reason
+      - If re-flagging, explicitly state what new evidence you have and why the prior dismissal was incorrect
+      - If no new evidence, skip this finding entirely — do not score it</action>
+    <action>If no dismissed findings section exists, proceed normally</action>
+  </step>
+
   <step n="2" goal="Build review attack plan">
     <action>Extract ALL Acceptance Criteria from story</action>
     <action>Extract ALL Tasks/Subtasks with completion status ([x] vs [ ])</action>

--- a/tests/antipatterns/test_dismissed_extractor.py
+++ b/tests/antipatterns/test_dismissed_extractor.py
@@ -1,0 +1,358 @@
+"""Tests for dismissed findings extraction and file appending."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from bmad_assist.antipatterns.dismissed_extractor import (
+    DISMISSED_ITEM_PATTERN,
+    DISMISSED_SECTION_PATTERN,
+    append_to_dismissed_findings_file,
+    extract_and_append_dismissed_findings,
+    extract_dismissed_findings,
+)
+
+
+class TestRegexPatterns:
+    """Tests for regex patterns used in dismissed findings extraction."""
+
+    def test_dismissed_section_pattern_basic(self):
+        """Test extraction of Issues Dismissed section."""
+        content = """
+## Issues Verified (by severity)
+
+### Critical
+- **Issue**: Test | **Fix**: Done
+
+## Issues Dismissed
+- **Claimed Issue**: AC6 not end-to-end | **Raised by**: Validator A (CRITICAL), Validator B (CRITICAL) | **Dismissal Reason**: Intentionally deferred to Story 5.3
+
+## Changes Applied
+Some changes.
+"""
+        match = DISMISSED_SECTION_PATTERN.search(content)
+        assert match is not None
+        section = match.group(1)
+        assert "AC6 not end-to-end" in section
+        assert "Changes Applied" not in section
+
+    def test_dismissed_section_pattern_ends_at_eof(self):
+        """Test section extraction when at end of file."""
+        content = """
+## Issues Verified
+### High
+- **Issue**: Test | **Fix**: Done
+
+## Issues Dismissed
+- **Claimed Issue**: False positive | **Raised by**: Reviewer A | **Dismissal Reason**: Stale context
+"""
+        match = DISMISSED_SECTION_PATTERN.search(content)
+        assert match is not None
+        assert "False positive" in match.group(1)
+
+    def test_dismissed_item_pattern_single(self):
+        """Test matching a single dismissed item."""
+        text = "- **Claimed Issue**: AC6 not end-to-end | **Raised by**: Validator A (CRITICAL), Validator B (CRITICAL) | **Dismissal Reason**: Intentionally deferred to Story 5.3"
+        matches = list(DISMISSED_ITEM_PATTERN.finditer(text))
+        assert len(matches) == 1
+        assert "AC6 not end-to-end" in matches[0].group(1)
+        assert "Validator A" in matches[0].group(2)
+        assert "deferred to Story 5.3" in matches[0].group(3)
+
+    def test_dismissed_item_pattern_multiple(self):
+        """Test matching multiple dismissed items."""
+        text = """- **Claimed Issue**: AC6 not end-to-end | **Raised by**: Validator A, B | **Dismissal Reason**: Deferred to Story 5.3
+- **Claimed Issue**: P1-BOOK-012 sanitization | **Raised by**: Validator B | **Dismissal Reason**: False positive - stale context
+"""
+        matches = list(DISMISSED_ITEM_PATTERN.finditer(text))
+        assert len(matches) == 2
+        assert "AC6" in matches[0].group(1)
+        assert "P1-BOOK-012" in matches[1].group(1)
+
+
+class TestExtractDismissedFindings:
+    """Tests for extract_dismissed_findings function."""
+
+    @pytest.fixture
+    def mock_config(self):
+        config = MagicMock()
+        config.antipatterns.enabled = True
+        return config
+
+    @pytest.fixture
+    def mock_config_disabled(self):
+        config = MagicMock()
+        config.antipatterns.enabled = False
+        return config
+
+    @pytest.fixture
+    def synthesis_with_dismissals(self):
+        return """
+<!-- CODE_REVIEW_SYNTHESIS_START -->
+## Synthesis Summary
+2 issues verified, 3 false positives dismissed, 2 fixes applied
+
+## Issues Verified (by severity)
+### Critical
+- **Issue**: Real bug | **Source**: Reviewer A | **Fix**: Fixed it
+
+## Issues Dismissed
+- **Claimed Issue**: AC6 not end-to-end | **Raised by**: Validator A (CRITICAL), Validator B (CRITICAL) | **Dismissal Reason**: Intentionally deferred to Story 5.3
+- **Claimed Issue**: P1-BOOK-012 sanitization missing | **Raised by**: Validator B (HIGH) | **Dismissal Reason**: False positive - stale context, already fixed in commit abc123
+- **Claimed Issue**: Missing WCAG contrast | **Raised by**: Reviewer C (MEDIUM) | **Dismissal Reason**: Design system enforces this at component level
+
+## Changes Applied
+Some changes listed here.
+<!-- CODE_REVIEW_SYNTHESIS_END -->
+"""
+
+    def test_extract_all_dismissed_findings(self, mock_config, synthesis_with_dismissals):
+        findings = extract_dismissed_findings(
+            synthesis_with_dismissals, epic_id=5, story_id="5-1", config=mock_config
+        )
+        assert len(findings) == 3
+        assert findings[0]["claimed_issue"] == "AC6 not end-to-end"
+        assert "Validator A" in findings[0]["raised_by"]
+        assert "deferred to Story 5.3" in findings[0]["dismissal_reason"]
+
+    def test_extract_preserves_all_fields(self, mock_config, synthesis_with_dismissals):
+        findings = extract_dismissed_findings(
+            synthesis_with_dismissals, epic_id=5, story_id="5-1", config=mock_config
+        )
+        for f in findings:
+            assert "claimed_issue" in f
+            assert "raised_by" in f
+            assert "dismissal_reason" in f
+            assert f["claimed_issue"]
+            assert f["dismissal_reason"]
+
+    def test_disabled_config_returns_empty(self, mock_config_disabled):
+        content = """
+## Issues Dismissed
+- **Claimed Issue**: Test | **Raised by**: A | **Dismissal Reason**: False positive
+"""
+        findings = extract_dismissed_findings(content, epic_id=5, story_id="5-1", config=mock_config_disabled)
+        assert findings == []
+
+    def test_empty_synthesis_returns_empty(self, mock_config):
+        findings = extract_dismissed_findings("", epic_id=5, story_id="5-1", config=mock_config)
+        assert findings == []
+
+    def test_no_dismissed_section_returns_empty(self, mock_config):
+        content = """
+## Issues Verified
+### Critical
+- **Issue**: Real bug | **Fix**: Fixed
+"""
+        findings = extract_dismissed_findings(content, epic_id=5, story_id="5-1", config=mock_config)
+        assert findings == []
+
+    def test_no_false_positives_message_returns_empty(self, mock_config):
+        content = """
+## Issues Dismissed
+No false positives identified.
+"""
+        findings = extract_dismissed_findings(content, epic_id=5, story_id="5-1", config=mock_config)
+        assert findings == []
+
+    def test_string_epic_id(self, mock_config):
+        content = """
+## Issues Dismissed
+- **Claimed Issue**: Test issue | **Raised by**: Reviewer A | **Dismissal Reason**: Not a real bug
+"""
+        findings = extract_dismissed_findings(
+            content, epic_id="testarch", story_id="testarch-01", config=mock_config
+        )
+        assert len(findings) == 1
+
+
+class TestAppendToDismissedFindingsFile:
+    """Tests for append_to_dismissed_findings_file function."""
+
+    @pytest.fixture
+    def sample_findings(self):
+        return [
+            {
+                "claimed_issue": "AC6 not end-to-end",
+                "raised_by": "Validator A, B",
+                "dismissal_reason": "Deferred to Story 5.3",
+            },
+            {
+                "claimed_issue": "P1-BOOK-012 sanitization",
+                "raised_by": "Validator B",
+                "dismissal_reason": "False positive - stale context",
+            },
+        ]
+
+    def test_creates_file_in_dismissed_findings_dir(self, tmp_path, sample_findings):
+        impl_artifacts = tmp_path / "_bmad-output" / "implementation-artifacts"
+        impl_artifacts.mkdir(parents=True)
+
+        with patch("bmad_assist.antipatterns.dismissed_extractor.get_paths") as mock_paths:
+            mock_paths.return_value.implementation_artifacts = impl_artifacts
+
+            append_to_dismissed_findings_file(
+                findings=sample_findings,
+                epic_id=5,
+                story_id="5-1",
+                project_path=tmp_path,
+            )
+
+        dismissed_dir = impl_artifacts / "dismissed-findings"
+        assert dismissed_dir.exists()
+
+        dismissed_file = dismissed_dir / "epic-5-dismissed-findings.md"
+        assert dismissed_file.exists()
+
+        content = dismissed_file.read_text()
+        assert "CONTEXT FOR REVIEWERS" in content
+        assert "Do NOT" in content
+        assert "Story 5-1" in content
+        assert "AC6 not end-to-end" in content
+        assert "Deferred to Story 5.3" in content
+
+    def test_table_format(self, tmp_path, sample_findings):
+        impl_artifacts = tmp_path / "_bmad-output" / "implementation-artifacts"
+        impl_artifacts.mkdir(parents=True)
+
+        with patch("bmad_assist.antipatterns.dismissed_extractor.get_paths") as mock_paths:
+            mock_paths.return_value.implementation_artifacts = impl_artifacts
+
+            append_to_dismissed_findings_file(
+                findings=sample_findings,
+                epic_id=5,
+                story_id="5-1",
+                project_path=tmp_path,
+            )
+
+        content = (impl_artifacts / "dismissed-findings" / "epic-5-dismissed-findings.md").read_text()
+        assert "| Finding | Raised By | Dismissal Reason |" in content
+        assert "|---------|-----------|------------------|" in content
+
+    def test_append_to_existing_file(self, tmp_path, sample_findings):
+        impl_artifacts = tmp_path / "_bmad-output" / "implementation-artifacts"
+        dismissed_dir = impl_artifacts / "dismissed-findings"
+        dismissed_dir.mkdir(parents=True)
+
+        dismissed_file = dismissed_dir / "epic-5-dismissed-findings.md"
+        initial_content = "# Epic 5 - Dismissed Findings\n\n## Story 5-1 (2026-03-01)\n\nExisting content"
+        dismissed_file.write_text(initial_content)
+
+        with patch("bmad_assist.antipatterns.dismissed_extractor.get_paths") as mock_paths:
+            mock_paths.return_value.implementation_artifacts = impl_artifacts
+
+            append_to_dismissed_findings_file(
+                findings=sample_findings,
+                epic_id=5,
+                story_id="5-2",
+                project_path=tmp_path,
+            )
+
+        content = dismissed_file.read_text()
+        assert "Story 5-1" in content
+        assert "Existing content" in content
+        assert "Story 5-2" in content
+        assert "AC6 not end-to-end" in content
+
+    def test_empty_findings_skips(self, tmp_path):
+        impl_artifacts = tmp_path / "_bmad-output" / "implementation-artifacts"
+        impl_artifacts.mkdir(parents=True)
+
+        with patch("bmad_assist.antipatterns.dismissed_extractor.get_paths") as mock_paths:
+            mock_paths.return_value.implementation_artifacts = impl_artifacts
+
+            append_to_dismissed_findings_file(
+                findings=[],
+                epic_id=5,
+                story_id="5-1",
+                project_path=tmp_path,
+            )
+
+        dismissed_dir = impl_artifacts / "dismissed-findings"
+        assert not dismissed_dir.exists()
+
+    def test_pipe_characters_escaped(self, tmp_path):
+        findings = [
+            {
+                "claimed_issue": "Issue with | pipe",
+                "raised_by": "Reviewer A | B",
+                "dismissal_reason": "Reason | with pipe",
+            }
+        ]
+
+        impl_artifacts = tmp_path / "_bmad-output" / "implementation-artifacts"
+        impl_artifacts.mkdir(parents=True)
+
+        with patch("bmad_assist.antipatterns.dismissed_extractor.get_paths") as mock_paths:
+            mock_paths.return_value.implementation_artifacts = impl_artifacts
+
+            append_to_dismissed_findings_file(
+                findings=findings,
+                epic_id=5,
+                story_id="5-1",
+                project_path=tmp_path,
+            )
+
+        content = (impl_artifacts / "dismissed-findings" / "epic-5-dismissed-findings.md").read_text()
+        assert "Issue with \\| pipe" in content
+        assert "Reviewer A \\| B" in content
+
+
+class TestExtractAndAppendDismissedFindings:
+    """Tests for the convenience wrapper function."""
+
+    def test_extract_and_append_full_pipeline(self, tmp_path):
+        config = MagicMock()
+        config.antipatterns.enabled = True
+
+        synthesis = """
+## Issues Dismissed
+- **Claimed Issue**: Test false positive | **Raised by**: Reviewer A | **Dismissal Reason**: Not a real issue
+
+## Changes Applied
+None.
+"""
+        impl_artifacts = tmp_path / "_bmad-output" / "implementation-artifacts"
+        impl_artifacts.mkdir(parents=True)
+
+        with patch("bmad_assist.antipatterns.dismissed_extractor.get_paths") as mock_paths:
+            mock_paths.return_value.implementation_artifacts = impl_artifacts
+
+            extract_and_append_dismissed_findings(
+                synthesis_content=synthesis,
+                epic_id=5,
+                story_id="5-1",
+                project_path=tmp_path,
+                config=config,
+            )
+
+        dismissed_file = impl_artifacts / "dismissed-findings" / "epic-5-dismissed-findings.md"
+        assert dismissed_file.exists()
+        content = dismissed_file.read_text()
+        assert "Test false positive" in content
+        assert "Not a real issue" in content
+
+    def test_extract_and_append_no_findings_no_file(self, tmp_path):
+        config = MagicMock()
+        config.antipatterns.enabled = True
+
+        synthesis = """
+## Issues Dismissed
+No false positives identified.
+"""
+        impl_artifacts = tmp_path / "_bmad-output" / "implementation-artifacts"
+        impl_artifacts.mkdir(parents=True)
+
+        with patch("bmad_assist.antipatterns.dismissed_extractor.get_paths") as mock_paths:
+            mock_paths.return_value.implementation_artifacts = impl_artifacts
+
+            extract_and_append_dismissed_findings(
+                synthesis_content=synthesis,
+                epic_id=5,
+                story_id="5-1",
+                project_path=tmp_path,
+                config=config,
+            )
+
+        dismissed_dir = impl_artifacts / "dismissed-findings"
+        assert not dismissed_dir.exists()


### PR DESCRIPTION
## Summary
- Extract and persist dismissed findings (false positives, intentional design decisions) from code review synthesis
- Inject dismissed findings into subsequent code review context so reviewers don't re-flag previously investigated issues
- Add step 1.5 to review instructions: check dismissed findings before raising issues, only re-flag with new evidence
- New `dismissed_extractor.py` module with tests

## Test plan
- [ ] Run `tests/antipatterns/test_dismissed_extractor.py` to verify extraction logic
- [ ] Verify dismissed findings file is created under `_bmad-output/implementation-artifacts/dismissed-findings/`
- [ ] Confirm code review compilation includes dismissed findings context
- [ ] Validate reviewers skip previously dismissed findings unless new evidence is provided

🤖 Generated with [Claude Code](https://claude.com/claude-code)