### PR TITLE
fix: run warnings/errors, sub-story parsing, and --backfill mode

### DIFF
--- a/src/bmad_assist/antipatterns/extractor.py
+++ b/src/bmad_assist/antipatterns/extractor.py
@@ -227,6 +227,14 @@ def extract_antipatterns(
         # Flush any remaining block
         _flush_block()
 
+    if section_match and not issues:
+        logger.debug(
+            "Issues Verified section found but 0 items extracted for story %s "
+            "(section length: %d chars)",
+            story_id,
+            len(section_match.group(0)),
+        )
+
     # --- Also extract dismissed findings (false positives) as severity="dismissed" ---
     # Idea credit: @derron1 (GitHub PR #39)
     dismissed_section = DISMISSED_SECTION_PATTERN.search(synthesis_content)

--- a/src/bmad_assist/benchmarking/ground_truth.py
+++ b/src/bmad_assist/benchmarking/ground_truth.py
@@ -536,7 +536,7 @@ def _atomic_update_record(record_path: Path, record: LLMEvaluationRecord) -> Non
 
 def populate_ground_truth(
     epic_num: int,
-    story_num: int,
+    story_num: int | str,
     code_review_output: str,
     base_dir: Path,
 ) -> list[GroundTruthUpdate]:

--- a/src/bmad_assist/benchmarking/master_tracking.py
+++ b/src/bmad_assist/benchmarking/master_tracking.py
@@ -85,7 +85,7 @@ def _analyze_output(output: str) -> OutputAnalysis:
 def create_master_record(
     workflow_id: str,
     epic_num: EpicId,
-    story_num: int,
+    story_num: int | str,
     story_title: str,
     provider: str,
     model: str,
@@ -160,7 +160,7 @@ def create_master_record(
 def save_master_timing(
     workflow_id: str,
     epic_num: EpicId,
-    story_num: int,
+    story_num: int | str,
     story_title: str,
     provider: str,
     model: str,

--- a/src/bmad_assist/benchmarking/storage.py
+++ b/src/bmad_assist/benchmarking/storage.py
@@ -95,7 +95,7 @@ class RecordFilters:
     date_from: datetime | None = None
     date_to: datetime | None = None
     epic: int | None = None
-    story: int | None = None
+    story: int | str | None = None
     provider: str | None = None
     role: EvaluatorRole | None = None
     workflow_id: str | None = None  # Filter by workflow.id (e.g., "code-review")

--- a/src/bmad_assist/benchmarking/storage.py
+++ b/src/bmad_assist/benchmarking/storage.py
@@ -113,7 +113,7 @@ class RecordSummary:
     path: Path
     record_id: str
     epic_num: int
-    story_num: int
+    story_num: int | str
     role_id: str | None
     provider: str
     created_at: datetime

--- a/src/bmad_assist/bmad/parser.py
+++ b/src/bmad_assist/bmad/parser.py
@@ -22,9 +22,10 @@ logger = logging.getLogger(__name__)
 
 # Regex patterns for epic file parsing
 # Pattern: ## Story X.Y: Title (2+ hashes - supports ##, ###, ####, etc.)
+# Supports sub-stories: 10.3a, 10.3a-ii, 10.3a-iii, 10.4b, etc.
 # Note: \s* before colon supports French typographic convention (space before colon)
 STORY_HEADER_PATTERN = re.compile(
-    r"^#{2,}\s+Story\s+(\d+)\.(\d+)\s*:\s+(.+)$",
+    r"^#{2,}\s+Story\s+(\d+)\.([\w]+(?:-[\w]+)*)\s*:\s+(.+)$",
     re.MULTILINE,
 )
 

--- a/src/bmad_assist/bmad/parser.py
+++ b/src/bmad_assist/bmad/parser.py
@@ -54,7 +54,7 @@ DEPENDENCIES_PATTERN = re.compile(
 )
 
 # Pattern to extract story numbers from dependencies
-STORY_NUMBER_PATTERN = re.compile(r"(\d+\.\d+)")
+STORY_NUMBER_PATTERN = re.compile(r"(\d+\.[\w]+(?:-[\w]+)*)")
 
 # Pattern for non-standard dependency codes like PRSP-5-1, REFACTOR-2-1
 NON_STANDARD_DEP_PATTERN = re.compile(r"([A-Z][A-Z0-9]*(?:-[A-Z0-9]+)+)", re.IGNORECASE)

--- a/src/bmad_assist/bmad/state_reader.py
+++ b/src/bmad_assist/bmad/state_reader.py
@@ -179,39 +179,75 @@ def _load_epics_from(bmad_path: Path) -> list[EpicDocument]:
         return epics
 
 
-def _story_sort_key(story: EpicStory) -> tuple[int, int | str, int]:
+def _natural_story_sort_key(story_part: str) -> tuple[int, str, list[str]]:
+    """Generate a natural sort key for story number part.
+
+    Handles pure numeric (3), letter-suffixed (3a, 4b), and
+    hyphenated sub-stories (3a-ii, 3a-iii).
+
+    Sort order: 3 < 3a < 3a-ii < 3a-iii < 3b < 3c < 4
+
+    Args:
+        story_part: Story number part after the dot (e.g., "3", "3a", "3a-ii").
+
+    Returns:
+        Tuple of (base_num, suffix, sub_parts) for natural ordering.
+
+    """
+    import re as _re
+
+    # Split into numeric prefix and optional alpha suffix
+    m = _re.match(r"^(\d+)(.*)", story_part)
+    if not m:
+        return (0, story_part, [])
+
+    base_num = int(m.group(1))
+    remainder = m.group(2)  # e.g., "", "a", "a-ii", "b"
+
+    # Split remainder on hyphens for sub-ordering
+    if remainder:
+        # "a-ii" -> suffix="a", sub_parts=["ii"]
+        # "a" -> suffix="a", sub_parts=[]
+        sub_parts = remainder.split("-")
+        suffix = sub_parts[0]  # "a", "b", etc.
+        sub_parts = sub_parts[1:]  # ["ii"], ["iii"], []
+    else:
+        suffix = ""  # Pure numeric sorts before any letter suffix
+        sub_parts = []
+
+    return (base_num, suffix, sub_parts)
+
+
+def _story_sort_key(story: EpicStory) -> tuple[int, int | str, tuple[int, str, list[str]]]:
     """Generate sort key for story ordering.
 
     Numeric epic IDs sort before string IDs.
+    Supports sub-stories like 3a, 3a-ii, 4b.
 
     Args:
         story: The EpicStory to generate a sort key for.
 
     Returns:
-        Tuple of (type_order, epic_id, story_num) for sorting.
+        Tuple of (type_order, epic_id, story_sort_key) for sorting.
         type_order: 0 for numeric epics, 1 for string epics.
-        Returns (0, 0, 0) for malformed story numbers.
+        Returns (0, 0, (0, "", [])) for malformed story numbers.
 
     """
     parts = story.number.split(".")
     if len(parts) != 2:
         logger.warning("Invalid story number format (expected X.Y): %s", story.number)
-        return (0, 0, 0)
+        return (0, 0, (0, "", []))
 
-    try:
-        story_num = int(parts[1])
-    except ValueError as e:
-        logger.warning("Non-numeric story number in %s: %s", story.number, e)
-        return (0, 0, 0)
+    story_key = _natural_story_sort_key(parts[1])
 
     epic_part = parts[0]
     try:
         # Numeric epic ID - sort first (type_order=0)
         epic_num = int(epic_part)
-        return (0, epic_num, story_num)
+        return (0, epic_num, story_key)
     except ValueError:
         # String epic ID - sort after numeric (type_order=1)
-        return (1, epic_part, story_num)
+        return (1, epic_part, story_key)
 
 
 def _flatten_stories(epics: list[EpicDocument]) -> list[EpicStory]:
@@ -306,6 +342,8 @@ def _parse_sprint_status_key(key: str) -> str | None:
 
     Sprint-status keys follow format:
     - Numeric: "X-Y-slug" (e.g., "2-1-markdown-parser") -> "2.1"
+    - Sub-story: "X-Ya-slug" (e.g., "10-3a-implement-...") -> "10.3a"
+    - Hyphenated sub: "X-Ya-ii-slug" (e.g., "10-3a-ii-implement-...") -> "10.3a-ii"
     - Module: "module-Y-slug" (e.g., "testarch-1-config") -> "testarch.1"
 
     Args:
@@ -315,21 +353,21 @@ def _parse_sprint_status_key(key: str) -> str | None:
         Story number in "X.Y" format, or None if key is not a story key.
 
     """
+    import re as _re
+
     # Skip epic keys (epic-N, module-X) and retrospective keys
     if key.startswith("epic-") or key.startswith("module-") or "retrospective" in key.lower():
         return None
 
-    parts = key.split("-")
-    if len(parts) >= 2:
-        # Try parsing story_num (second part must be numeric)
-        try:
-            story_num = int(parts[1])
-        except ValueError:
-            return None
-
-        # Epic part can be numeric or string (module name)
-        epic_part = parts[0]
-        return f"{epic_part}.{story_num}"
+    # Match: {epic}-{story_num}{optional_letter}{optional_roman_suffixes}-{slug}
+    # Examples: 10-3a-ii-implement-... -> epic=10, story=3a-ii
+    #           2-1-markdown-... -> epic=2, story=1
+    #           testarch-1-config -> epic=testarch, story=1
+    m = _re.match(r"^([^-]+)-(\d+[a-z]?(?:-[ivx]+)*)-", key)
+    if m:
+        epic_part = m.group(1)
+        story_part = m.group(2)
+        return f"{epic_part}.{story_part}"
 
     return None
 
@@ -409,19 +447,16 @@ def _load_sprint_status_stories(bmad_path: Path) -> list[EpicStory] | None:
                 if key.startswith("epic-") or key.endswith("-retrospective"):
                     continue
 
-                # Parse story key (e.g., "1-2-project-name" or "22-3-title")
-                # Format: epic-story-title (all hyphens)
-                parts = key.split("-", 2)  # ["1", "2", "project-name"] or max 3 parts
+                # Parse story key using shared parser
+                story_number = _parse_sprint_status_key(key)
+                if story_number is None:
+                    continue
 
-                if len(parts) < 3:
-                    continue  # Invalid format, skip
+                # Extract title from the slug portion after the story number
+                import re as _re
 
-                epic_part = parts[0]
-                story_part = parts[1]
-                title_part = parts[2] if len(parts) > 2 else key
-
-                story_number = f"{epic_part}.{story_part}"
-                title = title_part.replace("-", " ")  # Convert hyphens to spaces for title
+                m = _re.match(r"^[^-]+-\d+[a-z]?(?:-[ivx]+)*-(.+)$", key)
+                title = m.group(1).replace("-", " ") if m else key
 
                 if not isinstance(status, str):
                     continue

--- a/src/bmad_assist/bmad/state_reader.py
+++ b/src/bmad_assist/bmad/state_reader.py
@@ -363,7 +363,7 @@ def _parse_sprint_status_key(key: str) -> str | None:
     # Examples: 10-3a-ii-implement-... -> epic=10, story=3a-ii
     #           2-1-markdown-... -> epic=2, story=1
     #           testarch-1-config -> epic=testarch, story=1
-    m = _re.match(r"^([^-]+)-(\d+[a-z]?(?:-[ivx]+)*)-", key)
+    m = _re.match(r"^([^-]+)-(\d+(?:[a-z](?:-[ivx]{2,})*)?)-", key)
     if m:
         epic_part = m.group(1)
         story_part = m.group(2)
@@ -455,7 +455,7 @@ def _load_sprint_status_stories(bmad_path: Path) -> list[EpicStory] | None:
                 # Extract title from the slug portion after the story number
                 import re as _re
 
-                m = _re.match(r"^[^-]+-\d+[a-z]?(?:-[ivx]+)*-(.+)$", key)
+                m = _re.match(r"^[^-]+-\d+(?:[a-z](?:-[ivx]{2,})*)?-(.+)$", key)
                 title = m.group(1).replace("-", " ") if m else key
 
                 if not isinstance(status, str):

--- a/src/bmad_assist/cli.py
+++ b/src/bmad_assist/cli.py
@@ -37,7 +37,11 @@ from bmad_assist.core.config_generator import run_config_wizard
 from bmad_assist.core.exceptions import ConfigError
 from bmad_assist.core.io import get_original_cwd
 from bmad_assist.core.loop import LoopExitReason, run_loop
-from bmad_assist.core.loop.interactive import set_non_interactive, set_skip_story_prompts
+from bmad_assist.core.loop.interactive import (
+    set_backfill_enabled,
+    set_non_interactive,
+    set_skip_story_prompts,
+)
 from bmad_assist.core.paths import init_paths
 from bmad_assist.core.state import Phase, get_state_path, load_state, save_state, update_position
 from bmad_assist.core.types import EpicId, epic_sort_key, parse_epic_id
@@ -266,6 +270,11 @@ def run(
         "--skip-story-prompts",
         help="Skip continuation prompts between stories (but still prompt at epic boundaries)",
     ),
+    backfill: bool = typer.Option(
+        False,
+        "--backfill",
+        help="After current story, implement missed/skipped stories before continuing forward",
+    ),
     debug: bool = typer.Option(
         False,
         "--debug",
@@ -378,6 +387,10 @@ def run(
     # Set skip-story-prompts mode if flag is passed
     if skip_story_prompts:
         set_skip_story_prompts(True)
+
+    # Set backfill mode if flag is passed
+    if backfill:
+        set_backfill_enabled(True)
 
     # Set environment variables for flags
     if debug_jsonl:

--- a/src/bmad_assist/cli_start_point.py
+++ b/src/bmad_assist/cli_start_point.py
@@ -8,6 +8,7 @@ This module handles --epic and --story flag processing, including:
 """
 
 import logging
+import re
 import sys
 from pathlib import Path
 
@@ -129,9 +130,9 @@ def _handle_story_specified(
         typer.Exit: If story not found or cancelled.
 
     """
-    # Validate story_id is numeric
-    if not story_id.isdigit():
-        _error(f"Story number must be numeric, got: {story_id}")
+    # Validate story_id is a valid story number (e.g., "3", "3a", "3a-ii")
+    if not re.match(r"^\d+[a-z]*(?:-[a-z0-9]+)*$", story_id):
+        _error(f"Invalid story number format, got: {story_id}")
         raise typer.Exit(code=EXIT_CONFIG_ERROR)
 
     # User specified both epic and story

--- a/src/bmad_assist/code_review/orchestrator.py
+++ b/src/bmad_assist/code_review/orchestrator.py
@@ -46,6 +46,7 @@ from bmad_assist.benchmarking import (
 from bmad_assist.compiler import compile_workflow
 from bmad_assist.compiler.types import CompilerContext
 from bmad_assist.core.config import Config, get_phase_retries, get_phase_timeout
+from bmad_assist.core.config.models.features import ToolGuardConfig
 from bmad_assist.core.config.loaders import parse_parallel_delay
 from bmad_assist.core.config.models.providers import (
     MultiProviderConfig,
@@ -299,6 +300,7 @@ async def _invoke_reviewer(
     provider_name: str | None = None,
     thinking: bool | None = None,
     reasoning_effort: str | None = None,
+    tool_guard_config: ToolGuardConfig | None = None,
 ) -> tuple[str, ValidationOutput | None, DeterministicMetrics | None, str | None]:
     """Invoke a single reviewer using asyncio.to_thread.
 
@@ -335,7 +337,14 @@ async def _invoke_reviewer(
         # Per-provider guard for multi-LLM independence
         from bmad_assist.providers.tool_guard import ToolCallGuard
 
-        guard = ToolCallGuard()
+        if tool_guard_config is not None:
+            guard = ToolCallGuard(
+                max_total_calls=tool_guard_config.max_total_calls,
+                max_interactions_per_file=tool_guard_config.max_interactions_per_file,
+                max_calls_per_minute=tool_guard_config.max_calls_per_minute,
+            )
+        else:
+            guard = ToolCallGuard()
 
         # Setup fallback for claude-sdk provider (SDK init timeout -> subprocess)
         fallback_invoke_fn = None
@@ -776,6 +785,7 @@ async def run_code_review_phase(
             provider_name=multi_config.provider,
             thinking=multi_config.thinking,
             reasoning_effort=multi_config.reasoning_effort,
+            tool_guard_config=config.tool_guard,
         )
         task = asyncio.create_task(delayed_invoke(delay, coro))
         tasks.append(task)
@@ -806,6 +816,7 @@ async def run_code_review_phase(
             cwd=project_path,
             display_model=config.providers.master.display_model,
             provider_name=config.providers.master.provider,
+            tool_guard_config=config.tool_guard,
         )
         master_task = asyncio.create_task(delayed_invoke(master_delay, master_coro))
         tasks.append(master_task)

--- a/src/bmad_assist/code_review/orchestrator.py
+++ b/src/bmad_assist/code_review/orchestrator.py
@@ -52,7 +52,7 @@ from bmad_assist.core.config.models.providers import (
     MultiProviderConfig,
     get_phase_provider_config,
 )
-from bmad_assist.core.exceptions import BmadAssistError, CompilerError
+from bmad_assist.core.exceptions import BmadAssistError, CompilerError, ProviderError
 from bmad_assist.core.extraction import CODE_REVIEW_MARKERS, extract_report
 from bmad_assist.core.io import get_original_cwd, save_prompt
 from bmad_assist.core.loop.dashboard_events import (
@@ -475,7 +475,21 @@ async def _invoke_reviewer(
         logger.warning(error_msg)
         return reviewer_id, None, None, error_msg
 
+    except ProviderError as e:
+        # Expected operational failure from the provider layer (auth
+        # error, rate limit, non-zero exit, timeout, etc.). The error
+        # message already carries the diagnostic from stderr, and the
+        # Python stack trace through asyncio/retry/provider adds no
+        # information the operator can act on. Log cleanly without
+        # exc_info so multi-LLM parallel runs don't drown the log in
+        # duplicate tracebacks on a provider-wide outage.
+        error_msg = f"Reviewer {reviewer_id} failed: {e}"
+        logger.warning(error_msg)
+        return reviewer_id, None, None, error_msg
+
     except Exception as e:
+        # Unexpected exception (TypeError, AttributeError, etc.) —
+        # likely indicates a bmad-assist bug. Keep the full traceback.
         error_msg = f"Reviewer {reviewer_id} failed: {e}"
         logger.warning(error_msg, exc_info=True)
         return reviewer_id, None, None, error_msg

--- a/src/bmad_assist/code_review/orchestrator.py
+++ b/src/bmad_assist/code_review/orchestrator.py
@@ -46,8 +46,8 @@ from bmad_assist.benchmarking import (
 from bmad_assist.compiler import compile_workflow
 from bmad_assist.compiler.types import CompilerContext
 from bmad_assist.core.config import Config, get_phase_retries, get_phase_timeout
-from bmad_assist.core.config.models.features import ToolGuardConfig
 from bmad_assist.core.config.loaders import parse_parallel_delay
+from bmad_assist.core.config.models.features import ToolGuardConfig
 from bmad_assist.core.config.models.providers import (
     MultiProviderConfig,
     get_phase_provider_config,

--- a/src/bmad_assist/code_review/orchestrator.py
+++ b/src/bmad_assist/code_review/orchestrator.py
@@ -339,7 +339,12 @@ async def _invoke_reviewer(
 
         if tool_guard_config is not None:
             guard = ToolCallGuard(
-                max_total_calls=tool_guard_config.max_total_calls,
+                # Honor per-phase max_total_calls override (e.g. raised cap
+                # for heavy phases configured via
+                # tool_guard.max_total_calls_per_phase in bmad-assist.yaml).
+                max_total_calls=tool_guard_config.get_max_total_calls(
+                    "code_review"
+                ),
                 max_interactions_per_file=tool_guard_config.max_interactions_per_file,
                 max_calls_per_minute=tool_guard_config.max_calls_per_minute,
             )

--- a/src/bmad_assist/compiler/context.py
+++ b/src/bmad_assist/compiler/context.py
@@ -358,7 +358,7 @@ class ContextBuilder:
             self._add_file(single_epic_file, PRIORITY_EPIC)
             logger.debug("Added single epic file: %s", single_epic_file)
         else:
-            logger.warning("No epic files found for epic %s", epic_num)
+            logger.debug("No epic files found for epic %s (epics may be loaded from sharded loader)", epic_num)
 
         return self
 

--- a/src/bmad_assist/compiler/source_context.py
+++ b/src/bmad_assist/compiler/source_context.py
@@ -1011,6 +1011,189 @@ def _parse_git_stat(stat_output: str) -> list[tuple[str, int]]:
     return result
 
 
+# =============================================================================
+# Synthesis source file capping with markdown compression
+# =============================================================================
+#
+# Synthesis workflows (validate_story_synthesis, code_review_synthesis)
+# historically capped source files at 3 and dropped the overflow to
+# protect the LLM prompt budget. That was unnecessarily lossy for
+# markdown docs which can be safely compressed without losing the core
+# information reviewers need.
+#
+# This helper is the synthesis-side counterpart to
+# ``core.loop.handlers.base._try_compress_markdown_file_block`` — same
+# policy, different input shape (raw path→content dict vs XML blocks):
+#
+# - First ``max_files`` entries (highest-scored) are kept verbatim.
+# - For the tail, markdown files (.md/.markdown/.mdx) are compressed
+#   via the existing LLM compression helper and kept in the result.
+# - Source code is dropped — LLM summarization of code is unsafe for
+#   synthesis phases that compare implementation against the story.
+# - Very small markdown files (below _SYNTH_MIN_COMPRESSIBLE_TOKENS)
+#   are dropped outright; the LLM call overhead isn't worth the
+#   handful of tokens saved.
+
+_SYNTH_MARKDOWN_EXTENSIONS: tuple[str, ...] = (".md", ".markdown", ".mdx")
+_SYNTH_MIN_COMPRESSIBLE_TOKENS = 500
+_SYNTH_COMPRESSION_TARGET_RATIO = 0.5
+_SYNTH_MIN_COMPRESSION_TARGET_TOKENS = 200
+
+
+def _synth_doc_type_from_path(path: str) -> str:
+    """Build a cache key for per-path synthesis source compression.
+
+    Namespaced with ``synthsrc-`` so cache files don't collide with
+    strategic doc caches (``ux-*``, ``prd-*``) or the base-handler
+    trim-path cache (``srcmd-*``).
+    """
+    sanitized = re.sub(r"[^a-zA-Z0-9_-]+", "-", path).strip("-")
+    return f"synthsrc-{sanitized}"
+
+
+@dataclass(frozen=True)
+class SynthesisCapResult:
+    """Outcome of capping a dict of synthesis source files.
+
+    Attributes:
+        files: Resulting ``path → content`` dict. Entries present in
+            the input beyond ``max_files`` that were compressed appear
+            with their compressed (and annotated) content here.
+        kept_paths: Paths that survived unchanged.
+        compressed_paths: Paths whose content was compressed in place.
+        dropped_paths: Paths that were removed entirely (source code
+            overflow or markdown below the compression threshold).
+
+    """
+
+    files: dict[str, str]
+    kept_paths: list[str]
+    compressed_paths: list[str]
+    dropped_paths: list[str]
+
+
+def cap_synthesis_source_files(
+    source_files: dict[str, str],
+    *,
+    max_files: int,
+    project_root: Path | None,
+) -> SynthesisCapResult:
+    """Cap a synthesis source-file dict with compression-aware overflow.
+
+    Preserves the first ``max_files`` entries (by input order — callers
+    should pass files already ranked by score). For entries beyond the
+    cap: markdown is compressed and kept, source code is dropped.
+
+    Args:
+        source_files: Mapping of path → raw content, ordered by
+            relevance score (highest first). Typically the output of
+            :class:`SourceContextService.collect_files`.
+        max_files: Number of entries to preserve unchanged at the top.
+        project_root: Project root for the compression disk cache.
+            When None, compression is skipped entirely (all overflow
+            files are dropped — keeps the legacy test path working).
+
+    Returns:
+        SynthesisCapResult with the capped dict and per-category
+        path lists for logging/debugging.
+
+    """
+    if max_files < 0:
+        raise ValueError(f"max_files must be >= 0, got {max_files}")
+
+    if len(source_files) <= max_files:
+        return SynthesisCapResult(
+            files=dict(source_files),
+            kept_paths=list(source_files.keys()),
+            compressed_paths=[],
+            dropped_paths=[],
+        )
+
+    items = list(source_files.items())
+    kept_items = items[:max_files]
+    overflow_items = items[max_files:]
+
+    result_files: dict[str, str] = dict(kept_items)
+    compressed_paths: list[str] = []
+    dropped_paths: list[str] = []
+
+    # Lazy import to avoid circular deps: strategic_context imports
+    # several compiler modules during its own initialization.
+    _compress_or_truncate = None
+    try:
+        from bmad_assist.compiler.strategic_context import _compress_or_truncate as _c
+
+        _compress_or_truncate = _c
+    except ImportError as e:  # pragma: no cover - defensive
+        logger.debug("Synthesis compression unavailable: %s", e)
+
+    for path, content in overflow_items:
+        is_markdown = path.lower().endswith(_SYNTH_MARKDOWN_EXTENSIONS)
+
+        if not is_markdown or project_root is None or _compress_or_truncate is None:
+            dropped_paths.append(path)
+            continue
+
+        original_tokens = estimate_tokens(content)
+        if original_tokens < _SYNTH_MIN_COMPRESSIBLE_TOKENS:
+            # Too small to be worth the LLM round-trip.
+            dropped_paths.append(path)
+            continue
+
+        target_tokens = max(
+            int(original_tokens * _SYNTH_COMPRESSION_TARGET_RATIO),
+            _SYNTH_MIN_COMPRESSION_TARGET_TOKENS,
+        )
+
+        try:
+            compressed_content, compressed_tokens = _compress_or_truncate(
+                content,
+                target_tokens,
+                _synth_doc_type_from_path(path),
+                project_root,
+            )
+        except Exception as e:  # pragma: no cover - helper is fail-safe
+            logger.debug("Synthesis compression failed for %s: %s", path, e)
+            dropped_paths.append(path)
+            continue
+
+        # If compression didn't actually shrink, dropping is strictly
+        # better (saves tokens AND avoids a misleading "[compressed]"
+        # annotation on content that wasn't really compressed).
+        if len(compressed_content) >= len(content):
+            logger.debug(
+                "Synthesis compression no-op for %s (%d → %d chars), dropping",
+                path,
+                len(content),
+                len(compressed_content),
+            )
+            dropped_paths.append(path)
+            continue
+
+        annotated = (
+            f"[note: this file was compressed from ~{original_tokens} to "
+            f"~{compressed_tokens} tokens to fit the synthesis prompt budget. "
+            f"Request the full file via your file tools if you need exact "
+            f"content.]\n\n"
+            + compressed_content
+        )
+        result_files[path] = annotated
+        compressed_paths.append(path)
+        logger.info(
+            "Synthesis compress: shrank '%s' from %d to ~%d tokens",
+            path,
+            original_tokens,
+            len(annotated) // 4,
+        )
+
+    return SynthesisCapResult(
+        files=result_files,
+        kept_paths=[p for p, _ in kept_items],
+        compressed_paths=compressed_paths,
+        dropped_paths=dropped_paths,
+    )
+
+
 def get_hunk_ranges_for_file(project_root: Path, path: str) -> list[tuple[int, int]]:
     """Get hunk line ranges from git diff for a specific file.
 

--- a/src/bmad_assist/compiler/source_context.py
+++ b/src/bmad_assist/compiler/source_context.py
@@ -1012,27 +1012,35 @@ def _parse_git_stat(stat_output: str) -> list[tuple[str, int]]:
 
 
 # =============================================================================
-# Synthesis source file capping with markdown compression
+# Synthesis source file capping with LLM compression
 # =============================================================================
 #
 # Synthesis workflows (validate_story_synthesis, code_review_synthesis)
-# historically capped source files at 3 and dropped the overflow to
-# protect the LLM prompt budget. That was unnecessarily lossy for
-# markdown docs which can be safely compressed without losing the core
-# information reviewers need.
+# aggregate multi-reviewer findings into a consensus report. They reason
+# *over* existing reviewer output — they don't write code, they don't
+# need byte-exact source detail. This is a fundamentally different use
+# case from ``dev_story`` / ``code_review`` where byte-exact source is
+# load-bearing.
 #
-# This helper is the synthesis-side counterpart to
-# ``core.loop.handlers.base._try_compress_markdown_file_block`` — same
-# policy, different input shape (raw path→content dict vs XML blocks):
+# Because of that distinction, the synthesis-side capping policy is
+# deliberately more aggressive than the base-handler trim path:
 #
-# - First ``max_files`` entries (highest-scored) are kept verbatim.
-# - For the tail, markdown files (.md/.markdown/.mdx) are compressed
-#   via the existing LLM compression helper and kept in the result.
-# - Source code is dropped — LLM summarization of code is unsafe for
-#   synthesis phases that compare implementation against the story.
-# - Very small markdown files (below _SYNTH_MIN_COMPRESSIBLE_TOKENS)
-#   are dropped outright; the LLM call overhead isn't worth the
-#   handful of tokens saved.
+# - Every file above the compressibility threshold is compressed,
+#   regardless of file type (markdown OR source code) AND regardless
+#   of whether it was in the "top N" or the overflow.
+# - The annotation prepended to every compressed file instructs the
+#   synthesis agent to read the full file via its file tools when it
+#   needs exact content for verifying a reviewer claim.
+# - Files below _SYNTH_MIN_COMPRESSIBLE_TOKENS pass through verbatim
+#   (LLM round-trip overhead outweighs the savings).
+# - After compression, a ``max_files`` cap is still applied as an
+#   upper bound — if compression can't bring the total below
+#   ``max_files`` files' worth of output (e.g. huge inputs), the
+#   lowest-priority entries past the cap are dropped.
+#
+# For the conservative markdown-only / drop-code policy used by
+# ``dev_story`` and ``create_story``, see
+# ``core.loop.handlers.base._try_compress_markdown_file_block``.
 
 _SYNTH_MARKDOWN_EXTENSIONS: tuple[str, ...] = (".md", ".markdown", ".mdx")
 _SYNTH_MIN_COMPRESSIBLE_TOKENS = 500
@@ -1056,20 +1064,92 @@ class SynthesisCapResult:
     """Outcome of capping a dict of synthesis source files.
 
     Attributes:
-        files: Resulting ``path → content`` dict. Entries present in
-            the input beyond ``max_files`` that were compressed appear
-            with their compressed (and annotated) content here.
-        kept_paths: Paths that survived unchanged.
-        compressed_paths: Paths whose content was compressed in place.
-        dropped_paths: Paths that were removed entirely (source code
-            overflow or markdown below the compression threshold).
+        files: Resulting ``path → content`` dict. Compressed entries
+            appear with the LLM-compressed (and annotated) content.
+        included_paths: All paths present in ``files`` (both verbatim
+            and compressed).
+        compressed_paths: Subset of ``included_paths`` whose content
+            was replaced by an LLM summary. Small files (below the
+            compressibility threshold) are in ``included_paths`` but
+            NOT in ``compressed_paths`` — they pass through unchanged.
+        dropped_paths: Paths removed entirely because the input
+            exceeded ``max_files`` even after compression.
 
     """
 
     files: dict[str, str]
-    kept_paths: list[str]
+    included_paths: list[str]
     compressed_paths: list[str]
     dropped_paths: list[str]
+
+
+def _synthesis_compress_content(
+    path: str,
+    content: str,
+    project_root: Path,
+    compress_fn: "object",
+) -> str | None:
+    """Compress a single synthesis source file if worth it.
+
+    Returns the annotated compressed content, or None to indicate the
+    caller should keep the file verbatim (too small, no-op, or helper
+    failed). The caller decides what to do with None.
+
+    Args:
+        path: Repo-relative file path (used for cache keying).
+        content: Raw file content.
+        project_root: Project root for disk cache.
+        compress_fn: The ``_compress_or_truncate`` callable, injected
+            to avoid re-importing inside a hot loop.
+
+    Returns:
+        Compressed-and-annotated content, or None if compression was
+        skipped / failed / did not shrink.
+
+    """
+    original_tokens = estimate_tokens(content)
+    if original_tokens < _SYNTH_MIN_COMPRESSIBLE_TOKENS:
+        return None  # not worth the round-trip
+
+    target_tokens = max(
+        int(original_tokens * _SYNTH_COMPRESSION_TARGET_RATIO),
+        _SYNTH_MIN_COMPRESSION_TARGET_TOKENS,
+    )
+
+    try:
+        compressed_content, compressed_tokens = compress_fn(  # type: ignore[operator]
+            content,
+            target_tokens,
+            _synth_doc_type_from_path(path),
+            project_root,
+        )
+    except Exception as e:  # pragma: no cover - helper is fail-safe
+        logger.debug("Synthesis compression failed for %s: %s", path, e)
+        return None
+
+    if len(compressed_content) >= len(content):
+        logger.debug(
+            "Synthesis compression no-op for %s (%d → %d chars), keeping verbatim",
+            path,
+            len(content),
+            len(compressed_content),
+        )
+        return None
+
+    annotated = (
+        f"[note: this file was compressed from ~{original_tokens} to "
+        f"~{compressed_tokens} tokens to fit the synthesis prompt budget. "
+        f"Request the full file via your file tools if you need exact "
+        f"content.]\n\n"
+        + compressed_content
+    )
+    logger.info(
+        "Synthesis compress: shrank '%s' from %d to ~%d tokens",
+        path,
+        original_tokens,
+        len(annotated) // 4,
+    )
+    return annotated
 
 
 def cap_synthesis_source_files(
@@ -1078,117 +1158,99 @@ def cap_synthesis_source_files(
     max_files: int,
     project_root: Path | None,
 ) -> SynthesisCapResult:
-    """Cap a synthesis source-file dict with compression-aware overflow.
+    """Cap a synthesis source-file dict via aggressive LLM compression.
 
-    Preserves the first ``max_files`` entries (by input order — callers
-    should pass files already ranked by score). For entries beyond the
-    cap: markdown is compressed and kept, source code is dropped.
+    Compresses EVERY file above the compressibility threshold (regardless
+    of type — markdown and source code alike), then applies ``max_files``
+    as an upper bound on the result. Small files pass through verbatim.
+
+    This is the aggressive policy because synthesis phases reason over
+    existing reviewer output rather than writing new code. The annotation
+    prepended to each compressed file instructs the synthesis agent to
+    read the real file via tools when it needs byte-exact detail for
+    verification. For the conservative dev_story / create_story policy
+    (compress markdown, drop code), see
+    ``core.loop.handlers.base._try_compress_markdown_file_block``.
 
     Args:
         source_files: Mapping of path → raw content, ordered by
             relevance score (highest first). Typically the output of
             :class:`SourceContextService.collect_files`.
-        max_files: Number of entries to preserve unchanged at the top.
+        max_files: Upper bound on the number of files in the result.
+            Applied AFTER compression — if compression keeps the total
+            count at or below this, all files are included; otherwise
+            the lowest-priority entries are dropped.
         project_root: Project root for the compression disk cache.
-            When None, compression is skipped entirely (all overflow
-            files are dropped — keeps the legacy test path working).
+            When None, compression is skipped entirely and the helper
+            falls back to the legacy "keep top-N, drop the rest"
+            behavior (preserves unit-test ergonomics that don't want
+            to depend on the compression machinery).
 
     Returns:
-        SynthesisCapResult with the capped dict and per-category
+        SynthesisCapResult with ``files`` mapping and per-category
         path lists for logging/debugging.
 
     """
     if max_files < 0:
         raise ValueError(f"max_files must be >= 0, got {max_files}")
 
-    if len(source_files) <= max_files:
-        return SynthesisCapResult(
-            files=dict(source_files),
-            kept_paths=list(source_files.keys()),
-            compressed_paths=[],
-            dropped_paths=[],
-        )
-
     items = list(source_files.items())
-    kept_items = items[:max_files]
-    overflow_items = items[max_files:]
 
-    result_files: dict[str, str] = dict(kept_items)
-    compressed_paths: list[str] = []
-    dropped_paths: list[str] = []
-
-    # Lazy import to avoid circular deps: strategic_context imports
+    # Lazy import to avoid circular deps: strategic_context pulls in
     # several compiler modules during its own initialization.
-    _compress_or_truncate = None
-    try:
-        from bmad_assist.compiler.strategic_context import _compress_or_truncate as _c
-
-        _compress_or_truncate = _c
-    except ImportError as e:  # pragma: no cover - defensive
-        logger.debug("Synthesis compression unavailable: %s", e)
-
-    for path, content in overflow_items:
-        is_markdown = path.lower().endswith(_SYNTH_MARKDOWN_EXTENSIONS)
-
-        if not is_markdown or project_root is None or _compress_or_truncate is None:
-            dropped_paths.append(path)
-            continue
-
-        original_tokens = estimate_tokens(content)
-        if original_tokens < _SYNTH_MIN_COMPRESSIBLE_TOKENS:
-            # Too small to be worth the LLM round-trip.
-            dropped_paths.append(path)
-            continue
-
-        target_tokens = max(
-            int(original_tokens * _SYNTH_COMPRESSION_TARGET_RATIO),
-            _SYNTH_MIN_COMPRESSION_TARGET_TOKENS,
-        )
-
+    compress_fn: object | None = None
+    if project_root is not None:
         try:
-            compressed_content, compressed_tokens = _compress_or_truncate(
-                content,
-                target_tokens,
-                _synth_doc_type_from_path(path),
-                project_root,
+            from bmad_assist.compiler.strategic_context import (
+                _compress_or_truncate as _c,
             )
-        except Exception as e:  # pragma: no cover - helper is fail-safe
-            logger.debug("Synthesis compression failed for %s: %s", path, e)
-            dropped_paths.append(path)
-            continue
 
-        # If compression didn't actually shrink, dropping is strictly
-        # better (saves tokens AND avoids a misleading "[compressed]"
-        # annotation on content that wasn't really compressed).
-        if len(compressed_content) >= len(content):
-            logger.debug(
-                "Synthesis compression no-op for %s (%d → %d chars), dropping",
-                path,
-                len(content),
-                len(compressed_content),
-            )
-            dropped_paths.append(path)
-            continue
+            compress_fn = _c
+        except ImportError as e:  # pragma: no cover - defensive
+            logger.debug("Synthesis compression unavailable: %s", e)
 
-        annotated = (
-            f"[note: this file was compressed from ~{original_tokens} to "
-            f"~{compressed_tokens} tokens to fit the synthesis prompt budget. "
-            f"Request the full file via your file tools if you need exact "
-            f"content.]\n\n"
-            + compressed_content
+    # Legacy path: no compression available → fall back to the old
+    # "keep top-N verbatim, drop the rest" behavior so standalone unit
+    # tests and ad-hoc invocations stay deterministic.
+    if compress_fn is None or project_root is None:
+        kept = items[:max_files]
+        dropped = items[max_files:]
+        return SynthesisCapResult(
+            files=dict(kept),
+            included_paths=[p for p, _ in kept],
+            compressed_paths=[],
+            dropped_paths=[p for p, _ in dropped],
         )
-        result_files[path] = annotated
-        compressed_paths.append(path)
-        logger.info(
-            "Synthesis compress: shrank '%s' from %d to ~%d tokens",
-            path,
-            original_tokens,
-            len(annotated) // 4,
+
+    # Compress every eligible file (markdown AND source code) in place.
+    result_files: dict[str, str] = {}
+    compressed_paths: list[str] = []
+    for path, content in items:
+        compressed = _synthesis_compress_content(
+            path, content, project_root, compress_fn
         )
+        if compressed is None:
+            # Too small, no-op, or compression failed — keep verbatim.
+            result_files[path] = content
+        else:
+            result_files[path] = compressed
+            compressed_paths.append(path)
+
+    # Apply the upper bound last. Because we iterated in score order
+    # (input dict order), the first ``max_files`` entries in
+    # ``result_files`` are the highest-ranked.
+    included_items = list(result_files.items())[:max_files]
+    dropped_items = list(result_files.items())[max_files:]
+
+    final_files = dict(included_items)
+    dropped_paths = [p for p, _ in dropped_items]
+    # Don't report a compressed path as "included" if we then had to
+    # drop it for exceeding max_files.
+    compressed_paths = [p for p in compressed_paths if p in final_files]
 
     return SynthesisCapResult(
-        files=result_files,
-        kept_paths=[p for p, _ in kept_items],
+        files=final_files,
+        included_paths=[p for p, _ in included_items],
         compressed_paths=compressed_paths,
         dropped_paths=dropped_paths,
     )

--- a/src/bmad_assist/compiler/source_context.py
+++ b/src/bmad_assist/compiler/source_context.py
@@ -16,6 +16,7 @@ import ast
 import logging
 import re
 import subprocess
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -1083,11 +1084,18 @@ class SynthesisCapResult:
     dropped_paths: list[str]
 
 
+# Signature of compiler.strategic_context._compress_or_truncate — declared
+# here so the synthesis helper can type-check without introducing a real
+# import-time dependency (strategic_context pulls in several compiler
+# modules, so we lazy-import it inside the caller).
+_CompressFn = Callable[[str, int, str, "Path | None"], tuple[str, int]]
+
+
 def _synthesis_compress_content(
     path: str,
     content: str,
     project_root: Path,
-    compress_fn: "object",
+    compress_fn: _CompressFn,
 ) -> str | None:
     """Compress a single synthesis source file if worth it.
 
@@ -1117,7 +1125,7 @@ def _synthesis_compress_content(
     )
 
     try:
-        compressed_content, compressed_tokens = compress_fn(  # type: ignore[operator]
+        compressed_content, compressed_tokens = compress_fn(
             content,
             target_tokens,
             _synth_doc_type_from_path(path),
@@ -1198,7 +1206,7 @@ def cap_synthesis_source_files(
 
     # Lazy import to avoid circular deps: strategic_context pulls in
     # several compiler modules during its own initialization.
-    compress_fn: object | None = None
+    compress_fn: _CompressFn | None = None
     if project_root is not None:
         try:
             from bmad_assist.compiler.strategic_context import (

--- a/src/bmad_assist/compiler/strategic_context.py
+++ b/src/bmad_assist/compiler/strategic_context.py
@@ -300,7 +300,7 @@ def _compress_or_truncate(
             f"Output ONLY the compressed document, no preamble.\n\n"
             f"---\n{content}\n---"
         )
-        result = provider.invoke(prompt, model=helper.model, timeout=120)
+        result = provider.invoke(prompt, model=helper.model, timeout=helper.timeout)
         compressed = provider.parse_output(result).strip()
         actual = estimate_tokens(compressed)
 

--- a/src/bmad_assist/compiler/variables/core.py
+++ b/src/bmad_assist/compiler/variables/core.py
@@ -356,7 +356,7 @@ def resolve_variables(
 
         story_vars = _compute_story_variables(
             int(epic_num),
-            int(story_num),
+            story_num,
             sprint_status_path,
             epics_path,
             resolved.get("story_title"),

--- a/src/bmad_assist/compiler/variables/epic_story.py
+++ b/src/bmad_assist/compiler/variables/epic_story.py
@@ -26,7 +26,7 @@ __all__ = [
 
 def _compute_story_variables(
     epic_num: int,
-    story_num: int,
+    story_num: int | str,
     sprint_status_path: Path | None,
     epics_path: Path | None = None,
     story_title_override: str | None = None,
@@ -89,7 +89,7 @@ def _compute_story_variables(
 def _extract_story_title_from_epics(
     epics_path: Path,
     epic_num: int,
-    story_num: int,
+    story_num: int | str,
 ) -> str | None:
     r"""Extract story title from epics markdown file.
 

--- a/src/bmad_assist/compiler/variables/sprint_status.py
+++ b/src/bmad_assist/compiler/variables/sprint_status.py
@@ -79,7 +79,7 @@ def _resolve_sprint_status(
 def _extract_story_title(
     sprint_status_path: Path,
     epic_num: int,
-    story_num: int,
+    story_num: int | str,
 ) -> str | None:
     """Extract story title from sprint-status.yaml.
 

--- a/src/bmad_assist/compiler/workflows/code_review.py
+++ b/src/bmad_assist/compiler/workflows/code_review.py
@@ -110,10 +110,28 @@ def _capture_git_diff(context: CompilerContext) -> str:
         # - P0: Path filtering (excludes cache, metadata, node_modules, etc.)
         # - P0: Merge-base detection (handles merge commits correctly)
         # - P1: Quality validation (warns if garbage ratio too high)
+        # User-configurable garbage detection: load from config (best-effort,
+        # fall back to defaults if config isn't accessible — e.g. in tests).
+        max_garbage_ratio = 0.3
+        extra_garbage_patterns: tuple[str, ...] = ()
+        exclude_paths: tuple[str, ...] = ()
+        try:
+            from bmad_assist.core.config.loaders import get_config
+
+            git_cfg = get_config().git
+            max_garbage_ratio = git_cfg.max_garbage_ratio
+            extra_garbage_patterns = git_cfg.garbage_extra_patterns
+            exclude_paths = git_cfg.garbage_exclude_paths
+        except Exception:
+            # Config not loaded (tests, ad-hoc invocation) - use defaults
+            pass
+
         diff_content, validation = get_validated_diff(
             project_root,
-            max_garbage_ratio=0.3,
+            max_garbage_ratio=max_garbage_ratio,
             raise_on_invalid=False,  # Warn but don't block
+            extra_garbage_patterns=extra_garbage_patterns,
+            exclude_paths=exclude_paths,
         )
 
         # Log validation results for debugging

--- a/src/bmad_assist/compiler/workflows/code_review_synthesis.py
+++ b/src/bmad_assist/compiler/workflows/code_review_synthesis.py
@@ -362,28 +362,31 @@ class CodeReviewSynthesisCompiler:
             source_files = service.collect_files(file_list_paths, git_diff_files)
 
             # Hard cap: max 3 files for synthesis (prioritized by score).
-            # Instead of dropping overflow, compress markdown in place
-            # (preserving synthesis-relevant content) and drop only
-            # source code (LLM summarization is unsafe for code).
+            # cap_synthesis_source_files compresses EVERY file above the
+            # size threshold (markdown AND source code) rather than
+            # dropping overflow — synthesis reasons over reviewer output
+            # and doesn't write code, so compression is safe. Each
+            # compressed file carries an annotation telling the synthesis
+            # agent to read the real file via tools if it needs
+            # byte-exact detail for verifying a reviewer claim.
             max_synthesis_files = 3
             original_count = len(source_files)
-            if original_count > max_synthesis_files:
-                cap = cap_synthesis_source_files(
-                    source_files,
-                    max_files=max_synthesis_files,
-                    project_root=context.project_root,
+            cap = cap_synthesis_source_files(
+                source_files,
+                max_files=max_synthesis_files,
+                project_root=context.project_root,
+            )
+            source_files = cap.files
+            if cap.compressed_paths or cap.dropped_paths:
+                logger.info(
+                    "Synthesis source files capped: included=%d "
+                    "(compressed=%d) dropped=%d (input=%d, max=%d)",
+                    len(cap.included_paths),
+                    len(cap.compressed_paths),
+                    len(cap.dropped_paths),
+                    original_count,
+                    max_synthesis_files,
                 )
-                source_files = cap.files
-                if cap.compressed_paths or cap.dropped_paths:
-                    logger.info(
-                        "Synthesis source files capped: kept=%d "
-                        "compressed=%d dropped=%d (input=%d, max=%d)",
-                        len(cap.kept_paths),
-                        len(cap.compressed_paths),
-                        len(cap.dropped_paths),
-                        original_count,
-                        max_synthesis_files,
-                    )
 
             files.update(source_files)
             if source_files:

--- a/src/bmad_assist/compiler/workflows/code_review_synthesis.py
+++ b/src/bmad_assist/compiler/workflows/code_review_synthesis.py
@@ -46,6 +46,7 @@ from bmad_assist.compiler.shared_utils import (
 # Reuse git diff functions from code_review.py (until Epic 12 consolidation)
 from bmad_assist.compiler.source_context import (
     SourceContextService,
+    cap_synthesis_source_files,
     extract_file_paths_from_story,
     get_git_diff_files,
 )
@@ -360,18 +361,29 @@ class CodeReviewSynthesisCompiler:
             service = SourceContextService(context, "code_review_synthesis")
             source_files = service.collect_files(file_list_paths, git_diff_files)
 
-            # Hard cap: max 3 files for synthesis (prioritized by score)
+            # Hard cap: max 3 files for synthesis (prioritized by score).
+            # Instead of dropping overflow, compress markdown in place
+            # (preserving synthesis-relevant content) and drop only
+            # source code (LLM summarization is unsafe for code).
             max_synthesis_files = 3
-            if len(source_files) > max_synthesis_files:
-                # Sort by file path (deterministic) and take first 3
-                sorted_files = sorted(source_files.items(), key=lambda x: x[0])
-                limited_files = dict(sorted_files[:max_synthesis_files])
-                logger.warning(
-                    "Synthesis source files limited: %d → %d (token budget protection)",
-                    len(source_files),
-                    max_synthesis_files,
+            original_count = len(source_files)
+            if original_count > max_synthesis_files:
+                cap = cap_synthesis_source_files(
+                    source_files,
+                    max_files=max_synthesis_files,
+                    project_root=context.project_root,
                 )
-                source_files = limited_files
+                source_files = cap.files
+                if cap.compressed_paths or cap.dropped_paths:
+                    logger.info(
+                        "Synthesis source files capped: kept=%d "
+                        "compressed=%d dropped=%d (input=%d, max=%d)",
+                        len(cap.kept_paths),
+                        len(cap.compressed_paths),
+                        len(cap.dropped_paths),
+                        original_count,
+                        max_synthesis_files,
+                    )
 
             files.update(source_files)
             if source_files:

--- a/src/bmad_assist/compiler/workflows/create_story.py
+++ b/src/bmad_assist/compiler/workflows/create_story.py
@@ -466,7 +466,7 @@ class CreateStoryCompiler:
             logger.debug("Found single epic file: %s", epic_file)
             return [epic_file]
 
-        logger.warning("No epic files found for epic %s", epic_num)
+        logger.debug("No epic files found for epic %s (epics may be loaded from sharded loader)", epic_num)
         return []
 
     def _find_single_epic_file(self, context: CompilerContext, epic_num: Any) -> Path | None:

--- a/src/bmad_assist/compiler/workflows/retrospective.py
+++ b/src/bmad_assist/compiler/workflows/retrospective.py
@@ -37,7 +37,7 @@ logger = logging.getLogger(__name__)
 _WORKFLOW_RELATIVE_PATH = "_bmad/bmm/workflows/4-implementation/retrospective"
 
 # Pattern for story files
-_STORY_FILE_PATTERN = re.compile(r"^(\d+)-(\d+)-.+\.md$")
+_STORY_FILE_PATTERN = re.compile(r"^(\d+)-(\d+(?:[a-z](?:-[ivx]{2,})*)?)-.+\.md$")
 
 
 class RetrospectiveCompiler:

--- a/src/bmad_assist/compiler/workflows/testarch_base.py
+++ b/src/bmad_assist/compiler/workflows/testarch_base.py
@@ -137,8 +137,8 @@ class TestarchTriModalCompiler:
         if story_num is not None:
             story_path = self._find_story_file(context, epic_num, story_num)
             if story_path is None:
-                logger.warning(
-                    "Story file not found for %s-%s-*.md (non-blocking)",
+                logger.debug(
+                    "Story file not found for %s-%s-*.md (expected during epic setup)",
                     epic_num,
                     story_num,
                 )

--- a/src/bmad_assist/compiler/workflows/validate_story_synthesis.py
+++ b/src/bmad_assist/compiler/workflows/validate_story_synthesis.py
@@ -43,6 +43,7 @@ from bmad_assist.compiler.shared_utils import (
 )
 from bmad_assist.compiler.source_context import (
     SourceContextService,
+    cap_synthesis_source_files,
     extract_file_paths_from_story,
 )
 from bmad_assist.compiler.strategic_context import StrategicContextService
@@ -296,17 +297,31 @@ class ValidateStorySynthesisCompiler:
                     service = SourceContextService(context, "validate_story_synthesis")
                     source_files = service.collect_files(file_list_paths, None)
 
-                    # F4-IMPL: Limit source files for synthesis to prevent token explosion
+                    # F4-IMPL: Cap source files for synthesis to prevent token
+                    # explosion. Instead of hard-dropping overflow files, run
+                    # the compression-aware helper: markdown is compressed in
+                    # place (preserving synthesis-relevant content) while
+                    # source code overflow is dropped (summarization is
+                    # unsafe for code).
                     max_synthesis_files = 3
-                    if len(source_files) > max_synthesis_files:
-                        sorted_files = sorted(source_files.items(), key=lambda x: x[0])
-                        limited_files = dict(sorted_files[:max_synthesis_files])
-                        logger.warning(
-                            "Synthesis source files limited: %d → %d (token budget protection)",
-                            len(source_files),
-                            max_synthesis_files,
+                    original_count = len(source_files)
+                    if original_count > max_synthesis_files:
+                        cap = cap_synthesis_source_files(
+                            source_files,
+                            max_files=max_synthesis_files,
+                            project_root=context.project_root,
                         )
-                        source_files = limited_files
+                        source_files = cap.files
+                        if cap.compressed_paths or cap.dropped_paths:
+                            logger.info(
+                                "Synthesis source files capped: kept=%d "
+                                "compressed=%d dropped=%d (input=%d, max=%d)",
+                                len(cap.kept_paths),
+                                len(cap.compressed_paths),
+                                len(cap.dropped_paths),
+                                original_count,
+                                max_synthesis_files,
+                            )
 
                     files.update(source_files)
                     if source_files:

--- a/src/bmad_assist/compiler/workflows/validate_story_synthesis.py
+++ b/src/bmad_assist/compiler/workflows/validate_story_synthesis.py
@@ -297,31 +297,32 @@ class ValidateStorySynthesisCompiler:
                     service = SourceContextService(context, "validate_story_synthesis")
                     source_files = service.collect_files(file_list_paths, None)
 
-                    # F4-IMPL: Cap source files for synthesis to prevent token
-                    # explosion. Instead of hard-dropping overflow files, run
-                    # the compression-aware helper: markdown is compressed in
-                    # place (preserving synthesis-relevant content) while
-                    # source code overflow is dropped (summarization is
-                    # unsafe for code).
+                    # F4-IMPL: Cap source files for synthesis via aggressive
+                    # LLM compression. Synthesis phases reason over reviewer
+                    # output and don't write code, so we compress EVERY file
+                    # above the size threshold (markdown and source code
+                    # alike) rather than hard-dropping the overflow. Each
+                    # compressed file carries an annotation telling the
+                    # synthesis agent to read the real file via tools if it
+                    # needs byte-exact detail for verifying a reviewer claim.
                     max_synthesis_files = 3
                     original_count = len(source_files)
-                    if original_count > max_synthesis_files:
-                        cap = cap_synthesis_source_files(
-                            source_files,
-                            max_files=max_synthesis_files,
-                            project_root=context.project_root,
+                    cap = cap_synthesis_source_files(
+                        source_files,
+                        max_files=max_synthesis_files,
+                        project_root=context.project_root,
+                    )
+                    source_files = cap.files
+                    if cap.compressed_paths or cap.dropped_paths:
+                        logger.info(
+                            "Synthesis source files capped: included=%d "
+                            "(compressed=%d) dropped=%d (input=%d, max=%d)",
+                            len(cap.included_paths),
+                            len(cap.compressed_paths),
+                            len(cap.dropped_paths),
+                            original_count,
+                            max_synthesis_files,
                         )
-                        source_files = cap.files
-                        if cap.compressed_paths or cap.dropped_paths:
-                            logger.info(
-                                "Synthesis source files capped: kept=%d "
-                                "compressed=%d dropped=%d (input=%d, max=%d)",
-                                len(cap.kept_paths),
-                                len(cap.compressed_paths),
-                                len(cap.dropped_paths),
-                                original_count,
-                                max_synthesis_files,
-                            )
 
                     files.update(source_files)
                     if source_files:

--- a/src/bmad_assist/core/config/models/features.py
+++ b/src/bmad_assist/core/config/models/features.py
@@ -100,7 +100,7 @@ class ToolGuardConfig(BaseModel):
         json_schema_extra={"security": "safe", "ui_widget": "number"},
     )
     max_interactions_per_file: int = Field(
-        default=15,
+        default=25,
         ge=1,
         description="Max combined read+write+edit per file path",
         json_schema_extra={"security": "safe", "ui_widget": "number"},

--- a/src/bmad_assist/core/config/models/features.py
+++ b/src/bmad_assist/core/config/models/features.py
@@ -86,6 +86,11 @@ class ToolGuardConfig(BaseModel):
 
     Attributes:
         max_total_calls: Hard cap on total tool calls per invocation.
+        max_total_calls_per_phase: Optional per-phase overrides for
+            ``max_total_calls``. e.g. ``{"dev_story": 600}``. Phases not
+            listed fall back to ``max_total_calls``. Useful because
+            dev_story legitimately needs more tool calls than e.g. a
+            validation or review phase.
         max_interactions_per_file: Max combined read+write+edit per file path.
         max_interactions_per_file_trimmed: Elevated per-file cap for files
             that were budget-trimmed out of the prompt context. Such files
@@ -102,6 +107,15 @@ class ToolGuardConfig(BaseModel):
         ge=1,
         description="Hard cap on total tool calls per invocation",
         json_schema_extra={"security": "safe", "ui_widget": "number"},
+    )
+    max_total_calls_per_phase: dict[str, int] = Field(
+        default_factory=dict,
+        description=(
+            "Per-phase overrides for max_total_calls. Keys are phase names "
+            '(e.g. "dev_story", "create_story"), values are the total-call '
+            "cap for that phase. Phases not listed use max_total_calls."
+        ),
+        json_schema_extra={"security": "safe", "ui_widget": "object"},
     )
     max_interactions_per_file: int = Field(
         default=40,
@@ -139,6 +153,31 @@ class ToolGuardConfig(BaseModel):
         if self.max_interactions_per_file_trimmed is not None:
             return self.max_interactions_per_file_trimmed
         return self.max_interactions_per_file * 2
+
+    def get_max_total_calls(self, phase: str) -> int:
+        """Resolve max_total_calls for a specific phase.
+
+        Normalizes hyphens to underscores so callers can pass either
+        ``"dev_story"`` or ``"dev-story"``. Falls back to
+        ``max_total_calls`` for phases without an explicit override.
+
+        Args:
+            phase: Phase name (e.g. "dev_story", "code_review").
+
+        Returns:
+            Per-phase cap when configured, otherwise the global default.
+
+        """
+        normalized = phase.replace("-", "_")
+        override = self.max_total_calls_per_phase.get(normalized)
+        if override is not None:
+            if override < 1:
+                # Treat a misconfigured 0/negative as "use default" rather
+                # than throwing — the guard constructor validates >=1
+                # separately and would otherwise crash the run.
+                return self.max_total_calls
+            return override
+        return self.max_total_calls
 
 
 class GitConfig(BaseModel):

--- a/src/bmad_assist/core/config/models/features.py
+++ b/src/bmad_assist/core/config/models/features.py
@@ -100,7 +100,7 @@ class ToolGuardConfig(BaseModel):
         json_schema_extra={"security": "safe", "ui_widget": "number"},
     )
     max_interactions_per_file: int = Field(
-        default=25,
+        default=40,
         ge=1,
         description="Max combined read+write+edit per file path",
         json_schema_extra={"security": "safe", "ui_widget": "number"},

--- a/src/bmad_assist/core/config/models/features.py
+++ b/src/bmad_assist/core/config/models/features.py
@@ -87,6 +87,10 @@ class ToolGuardConfig(BaseModel):
     Attributes:
         max_total_calls: Hard cap on total tool calls per invocation.
         max_interactions_per_file: Max combined read+write+edit per file path.
+        max_interactions_per_file_trimmed: Elevated per-file cap for files
+            that were budget-trimmed out of the prompt context. Such files
+            must be read via tool calls, so they need a higher cap. None
+            means "auto: 2x max_interactions_per_file".
         max_calls_per_minute: Sliding-window rate cap (calls per 60s).
 
     """
@@ -105,10 +109,82 @@ class ToolGuardConfig(BaseModel):
         description="Max combined read+write+edit per file path",
         json_schema_extra={"security": "safe", "ui_widget": "number"},
     )
+    max_interactions_per_file_trimmed: int | None = Field(
+        default=None,
+        ge=1,
+        description=(
+            "Elevated per-file cap for files that were budget-trimmed out of "
+            "the prompt context (model must read them via tools). None = auto, "
+            "uses 2x max_interactions_per_file."
+        ),
+        json_schema_extra={"security": "safe", "ui_widget": "number"},
+    )
     max_calls_per_minute: int = Field(
         default=90,
         ge=1,
         description="Sliding-window rate cap (calls per 60s)",
+        json_schema_extra={"security": "safe", "ui_widget": "number"},
+    )
+
+    def get_elevated_file_cap(self) -> int:
+        """Resolve the elevated per-file cap.
+
+        Returns max_interactions_per_file_trimmed when set, otherwise auto:
+        2 * max_interactions_per_file.
+
+        Returns:
+            Effective elevated per-file interaction cap.
+
+        """
+        if self.max_interactions_per_file_trimmed is not None:
+            return self.max_interactions_per_file_trimmed
+        return self.max_interactions_per_file * 2
+
+
+class GitConfig(BaseModel):
+    """Git diff handling configuration.
+
+    Controls how bmad-assist filters and validates diffs for code review.
+
+    Attributes:
+        garbage_exclude_paths: Additional file paths or glob-style patterns
+            that the diff-quality validator must NOT classify as "garbage".
+            Use this to whitelist tracked files like ".opencode/package-lock.json"
+            that legitimately appear in your diffs.
+        garbage_extra_patterns: Additional regex patterns to classify as
+            garbage (appended to the built-in list). Use this when your repo
+            generates files the defaults don't cover.
+        max_garbage_ratio: Maximum allowed ratio of garbage files in a diff
+            before the validator flags it (0.0-1.0).
+
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    garbage_exclude_paths: tuple[str, ...] = Field(
+        default=(),
+        description=(
+            "Repo-relative paths or glob patterns to whitelist from garbage "
+            "detection. E.g. ['.opencode/package-lock.json', 'vendor/*.lock']."
+        ),
+        json_schema_extra={"security": "safe", "ui_widget": "list"},
+    )
+    garbage_extra_patterns: tuple[str, ...] = Field(
+        default=(),
+        description=(
+            "Additional regex patterns to classify as garbage (appended to "
+            "the built-in list)."
+        ),
+        json_schema_extra={"security": "safe", "ui_widget": "list"},
+    )
+    max_garbage_ratio: float = Field(
+        default=0.3,
+        ge=0.0,
+        le=1.0,
+        description=(
+            "Max ratio of garbage files in a diff before the validator flags "
+            "it. 0.0-1.0."
+        ),
         json_schema_extra={"security": "safe", "ui_widget": "number"},
     )
 

--- a/src/bmad_assist/core/config/models/main.py
+++ b/src/bmad_assist/core/config/models/main.py
@@ -9,6 +9,7 @@ from bmad_assist.core.config.models.features import (
     AntipatternConfig,
     BenchmarkingConfig,
     CompilerConfig,
+    GitConfig,
     QAConfig,
     TimeoutsConfig,
     ToolGuardConfig,
@@ -149,6 +150,10 @@ class Config(BaseModel):
     tool_guard: ToolGuardConfig = Field(
         default_factory=ToolGuardConfig,
         description="ToolCallGuard watchdog thresholds (optional)",
+    )
+    git: GitConfig = Field(
+        default_factory=GitConfig,
+        description="Git diff handling configuration (garbage detection, etc.)",
     )
 
     @model_validator(mode="before")

--- a/src/bmad_assist/core/config/models/providers.py
+++ b/src/bmad_assist/core/config/models/providers.py
@@ -208,6 +208,12 @@ class HelperProviderConfig(BaseModel):
         description="Model identifier for CLI: haiku, sonnet, etc.",
         json_schema_extra={"security": "risky", "ui_widget": "dropdown"},
     )
+    timeout: int = Field(
+        default=120,
+        ge=10,
+        description="Timeout in seconds for helper LLM calls (eligibility, summarization)",
+        json_schema_extra={"security": "safe", "ui_widget": "number", "unit": "s"},
+    )
     model_name: str | None = Field(
         None,
         description="Display name for model (used in logs/reports instead of model)",

--- a/src/bmad_assist/core/extraction.py
+++ b/src/bmad_assist/core/extraction.py
@@ -138,6 +138,7 @@ def extract_report(
     markers: ReportMarkers,
     *,
     stop_at_markers: list[str] | None = None,
+    termination_reason: str | None = None,
 ) -> str:
     r"""Extract report content from LLM output.
 
@@ -194,11 +195,20 @@ def extract_report(
         return content
 
     # Stage 3: Last resort - return stripped original
-    logger.warning(
-        "Could not extract structured %s report, using raw content (%d chars)",
-        markers.name,
-        len(raw_output.strip()),
-    )
+    if termination_reason and "guard" in termination_reason.lower():
+        logger.warning(
+            "ToolCallGuard terminated %s phase before report markers could be "
+            "emitted — output likely incomplete (%d chars, reason: %s)",
+            markers.name,
+            len(raw_output.strip()),
+            termination_reason,
+        )
+    else:
+        logger.warning(
+            "Could not extract structured %s report, using raw content (%d chars)",
+            markers.name,
+            len(raw_output.strip()),
+        )
     return raw_output.strip()
 
 

--- a/src/bmad_assist/core/io.py
+++ b/src/bmad_assist/core/io.py
@@ -25,6 +25,7 @@ __all__ = [
     "get_timestamp",
     "get_run_prompts_dir",
     "init_run_prompts_dir",
+    "get_current_run_dir",
     "get_original_cwd",
 ]
 
@@ -79,6 +80,23 @@ def _get_run_dir() -> Path | None:
 
     """
     return getattr(_run_context, "prompts_dir", None)
+
+
+def get_current_run_dir() -> Path | None:
+    """Public accessor for the current run-scoped prompts directory.
+
+    Returns the directory initialized by init_run_prompts_dir() for the
+    active bmad-assist run, or None if no run is active (e.g. unit tests,
+    ad-hoc provider invocations outside the loop).
+
+    Used by providers to write per-run diagnostic files (SDK stderr dumps,
+    debug artifacts) alongside the saved prompts.
+
+    Returns:
+        Path to the current run-scoped dir, or None if not initialized.
+
+    """
+    return _get_run_dir()
 
 
 def _get_prompt_counter() -> int:

--- a/src/bmad_assist/core/loop/backfill.py
+++ b/src/bmad_assist/core/loop/backfill.py
@@ -1,0 +1,115 @@
+"""Backfill mode: detect and queue missed/skipped stories.
+
+When --backfill is enabled, after completing the current story the runner
+scans for "gap" stories — stories that exist in the epic list but were
+never completed and come before the current forward position. These are
+queued for execution before normal forward advancement resumes.
+
+Gap stories arise when:
+- Sub-stories (3a, 3a-ii, 4b) were not parsed by older regex
+- Stories were added to epics after the epic was partially implemented
+- Stories were skipped due to parser bugs
+
+Stories with "deferred" status in sprint-status are excluded — they
+represent intentionally postponed work.
+"""
+
+import logging
+from collections.abc import Callable
+
+from bmad_assist.bmad.state_reader import _natural_story_sort_key
+from bmad_assist.core.types import EpicId
+
+logger = logging.getLogger(__name__)
+
+# Statuses that indicate a story should NOT be backfilled
+_SKIP_STATUSES = {"done", "deferred", "skipped", "cancelled"}
+
+
+def detect_backfill_stories(
+    completed_stories: list[str],
+    current_story: str,
+    epic_list: list[EpicId],
+    epic_stories_loader: Callable[[EpicId], list[str]],
+    sprint_statuses: dict[str, str] | None = None,
+) -> list[str]:
+    """Detect stories that should be backfilled.
+
+    Scans all stories across all epics and finds those that:
+    1. Are NOT in completed_stories
+    2. Come BEFORE current_story in natural sort order
+    3. Are NOT marked as done/deferred/skipped in sprint-status
+
+    Args:
+        completed_stories: List of story IDs already completed.
+        current_story: The story that was just completed (forward frontier).
+        epic_list: Ordered list of all epic IDs.
+        epic_stories_loader: Function to get stories for an epic.
+        sprint_statuses: Optional dict mapping story IDs to statuses
+            from sprint-status.yaml.
+
+    Returns:
+        Ordered list of story IDs to backfill, sorted in natural order.
+        Empty list if no gaps found.
+
+    """
+    completed_set = set(completed_stories)
+    if sprint_statuses is None:
+        sprint_statuses = {}
+
+    # Collect all stories across all epics in order
+    all_stories: list[str] = []
+    for epic_id in epic_list:
+        stories = epic_stories_loader(epic_id)
+        all_stories.extend(stories)
+
+    # Find the position of current_story (the forward frontier)
+    # Everything before this position is eligible for backfill
+    frontier_key = _story_global_sort_key(current_story)
+
+    gaps: list[str] = []
+    for story_id in all_stories:
+        # Must come before the frontier
+        if _story_global_sort_key(story_id) >= frontier_key:
+            continue
+
+        # Must not be already completed
+        if story_id in completed_set:
+            continue
+
+        # Must not be in a skip status
+        status = sprint_statuses.get(story_id, "").lower()
+        if status in _SKIP_STATUSES:
+            continue
+
+        gaps.append(story_id)
+
+    # Sort gaps in natural order
+    gaps.sort(key=_story_global_sort_key)
+
+    if gaps:
+        logger.info(
+            "Backfill: detected %d gap stories before %s: %s",
+            len(gaps),
+            current_story,
+            ", ".join(gaps),
+        )
+
+    return gaps
+
+
+def _story_global_sort_key(story_id: str) -> tuple:
+    """Generate a global sort key for a story ID like '10.3a'.
+
+    Combines epic number and story part for cross-epic ordering.
+    """
+    parts = story_id.split(".")
+    if len(parts) != 2:
+        return (0, 0, (0, "", []))
+
+    epic_part = parts[0]
+    try:
+        epic_num = int(epic_part)
+        return (0, epic_num, _natural_story_sort_key(parts[1]))
+    except ValueError:
+        return (1, epic_part, _natural_story_sort_key(parts[1]))

--- a/src/bmad_assist/core/loop/backfill.py
+++ b/src/bmad_assist/core/loop/backfill.py
@@ -98,7 +98,7 @@ def detect_backfill_stories(
     return gaps
 
 
-def _story_global_sort_key(story_id: str) -> tuple:
+def _story_global_sort_key(story_id: str) -> tuple[int, int | str, tuple[int, str, list[str]]]:
     """Generate a global sort key for a story ID like '10.3a'.
 
     Combines epic number and story part for cross-epic ordering.

--- a/src/bmad_assist/core/loop/dashboard_events.py
+++ b/src/bmad_assist/core/loop/dashboard_events.py
@@ -117,7 +117,7 @@ def emit_story_status(
     run_id: str,
     sequence_id: int,
     epic_num: EpicId,
-    story_num: int,
+    story_num: int | str,
     story_id: str,
     status: Literal["backlog", "ready-for-dev", "in-progress", "review", "done"],
     previous_status: (
@@ -160,7 +160,7 @@ def emit_story_transition(
     sequence_id: int,
     action: Literal["started", "completed"],
     epic_num: EpicId,
-    story_num: int,
+    story_num: int | str,
     story_id: str,
     story_title: str,
 ) -> None:

--- a/src/bmad_assist/core/loop/handlers/base.py
+++ b/src/bmad_assist/core/loop/handlers/base.py
@@ -1069,8 +1069,13 @@ class BaseHandler(ABC):
         # Pass budget-trimmed files into the guard so they get the elevated
         # per-file cap. Empty set = no elevation, behavior unchanged.
         elevated_paths = set(self._budget_trimmed_paths)
+        # Resolve max_total_calls per-phase. dev_story legitimately needs
+        # many more tool calls than e.g. validation phases, so users can
+        # set ``tool_guard.max_total_calls_per_phase: {dev_story: 600}``
+        # in config to raise just the phase that needs it.
+        phase_max_total_calls = tg.get_max_total_calls(self.phase_name)
         guard = ToolCallGuard(
-            max_total_calls=tg.max_total_calls,
+            max_total_calls=phase_max_total_calls,
             max_interactions_per_file=tg.max_interactions_per_file,
             max_calls_per_minute=tg.max_calls_per_minute,
             elevated_file_paths=elevated_paths,

--- a/src/bmad_assist/core/loop/handlers/base.py
+++ b/src/bmad_assist/core/loop/handlers/base.py
@@ -106,57 +106,302 @@ _FILE_BLOCK_RE = re.compile(
     re.DOTALL,
 )
 
+# Markdown extensions eligible for compression instead of full drop.
+# Source code files (.py/.rs/.ts/etc.) are intentionally excluded — LLM
+# summarization of code can silently lose type signatures and exact API
+# shapes, which is unacceptable for dev_story / code_review phases. They
+# stay on the drop path and rely on the elevated ToolCallGuard cap so the
+# model can read exact bytes via tools when needed.
+_MARKDOWN_EXTENSIONS: tuple[str, ...] = (".md", ".markdown", ".mdx")
 
-def _trim_source_context(prompt: str, current_tokens: int, budget: int) -> str:
-    """Trim lowest-priority source files from compiled prompt to fit budget.
+# Files smaller than this aren't worth compressing — LLM call latency
+# dwarfs the byte savings.
+_MIN_COMPRESSIBLE_TOKENS = 500
+
+# Compress to ~50% of original (matches strategic-context defaults).
+_COMPRESSION_TARGET_RATIO = 0.5
+
+# Floor on compression target so we don't ask the LLM for an unrealistic
+# size on borderline-eligible files.
+_MIN_COMPRESSION_TARGET_TOKENS = 200
+
+# CDATA wrapper format used by compiler.output._wrap_cdata. Kept here
+# verbatim so the unwrap helper stays a pure inverse — if _wrap_cdata
+# changes shape, both sides need updating together.
+_CDATA_OPEN = "<![CDATA[\n\n"
+_CDATA_CLOSE = "\n\n]]>"
+_CDATA_SPLIT_REJOIN = "\n\n]]]]><![CDATA[\n\n"
+
+
+def _extract_file_block_content(block: str) -> str | None:
+    """Extract content from a CDATA-wrapped ``<file>`` block.
+
+    Inverts the wrapping done by ``compiler.output._wrap_cdata`` and the
+    ``<file>`` element. Returns None if the block doesn't match the
+    expected shape (caller treats this as "compression not applicable").
+
+    Handles split CDATA sections (when the original content contained
+    ``]]>``, _wrap_cdata splits into multiple sections and rejoins with
+    ``]]]]><![CDATA[``).
+
+    Args:
+        block: Full ``<file id=... path=...>...</file>`` block text.
+
+    Returns:
+        Original content string, or None if the block is malformed.
+
+    """
+    open_tag_end = block.find(">")
+    if open_tag_end == -1:
+        return None
+    close_tag_start = block.rfind("</file>")
+    if close_tag_start == -1 or close_tag_start <= open_tag_end:
+        return None
+
+    inner = block[open_tag_end + 1 : close_tag_start]
+    if not inner.startswith(_CDATA_OPEN) or not inner.endswith(_CDATA_CLOSE):
+        return None
+
+    content = inner[len(_CDATA_OPEN) : -len(_CDATA_CLOSE)]
+    # Reverse the _wrap_cdata splitting: rejoin split CDATA sections.
+    return content.replace(_CDATA_SPLIT_REJOIN, "]]>")
+
+
+def _build_file_block_with_content(original_block: str, new_content: str) -> str | None:
+    """Re-wrap a ``<file>`` block with new content, preserving attributes.
+
+    Lazy-imports ``_wrap_cdata`` to avoid a circular dep at module load.
+
+    Args:
+        original_block: The original full ``<file>`` block (used for the
+            opening tag with id/path/label attributes).
+        new_content: Replacement content to wrap in CDATA.
+
+    Returns:
+        The new full ``<file>`` block, or None if the original is malformed.
+
+    """
+    open_tag_end = original_block.find(">")
+    close_tag_start = original_block.rfind("</file>")
+    if open_tag_end == -1 or close_tag_start == -1 or close_tag_start <= open_tag_end:
+        return None
+
+    open_tag = original_block[: open_tag_end + 1]
+    from bmad_assist.compiler.output import _wrap_cdata
+
+    return open_tag + _wrap_cdata(new_content) + "</file>"
+
+
+def _sanitize_doc_type_from_path(path: str) -> str:
+    """Build a cache-friendly doc_type identifier from a file path.
+
+    The compression cache (``compiler/strategic_context.py``) keys by
+    ``doc_type`` — each doc_type stores at most one cached file, with
+    stale entries auto-pruned when the source content changes. Using a
+    per-path doc_type means each markdown file gets its own cache entry
+    that's invalidated automatically on content change.
+
+    Strategic doc cache uses bare prefixes like ``ux``, ``prd``. We use
+    ``srcmd-`` to namespace source-tree markdown caches and avoid any
+    collision with strategic doc cache files.
+
+    Args:
+        path: Repo-relative file path from the XML attribute.
+
+    Returns:
+        Sanitized doc_type identifier safe to use as a filename prefix.
+
+    """
+    sanitized = re.sub(r"[^a-zA-Z0-9_-]+", "-", path).strip("-")
+    return f"srcmd-{sanitized}"
+
+
+def _try_compress_markdown_file_block(
+    prompt: str,
+    match: "re.Match[str]",
+    path: str,
+    project_root: Path,
+) -> str | None:
+    """Attempt to compress a markdown ``<file>`` block in place.
+
+    Calls the existing ``_compress_or_truncate`` helper (LLM-based
+    compression with disk caching, falling back to truncation). Annotates
+    the compressed content so the model knows it's a summary and can read
+    the full file via tools (the elevated ToolCallGuard cap covers it).
+
+    Args:
+        prompt: Current prompt text (will be spliced).
+        match: Regex match for the ``<file>`` block (positions are
+            relative to the ORIGINAL prompt — the caller must iterate
+            in reverse so positions stay valid as later blocks change).
+        path: Path attribute from the XML, used for cache key + logging.
+        project_root: Project root for the disk cache.
+
+    Returns:
+        The new prompt text on success, or None if compression should
+        be skipped (caller falls back to dropping the file).
+
+    """
+    block = match.group(0)
+    content = _extract_file_block_content(block)
+    if content is None:
+        logger.debug("Compression skipped for %s: could not extract CDATA", path)
+        return None
+
+    original_tokens = len(content) // 4
+    if original_tokens < _MIN_COMPRESSIBLE_TOKENS:
+        logger.debug(
+            "Compression skipped for %s: only %d tokens (< %d threshold)",
+            path,
+            original_tokens,
+            _MIN_COMPRESSIBLE_TOKENS,
+        )
+        return None
+
+    target_tokens = max(
+        int(original_tokens * _COMPRESSION_TARGET_RATIO),
+        _MIN_COMPRESSION_TARGET_TOKENS,
+    )
+
+    try:
+        from bmad_assist.compiler.strategic_context import _compress_or_truncate
+    except ImportError as e:  # pragma: no cover - defensive
+        logger.debug("Compression module unavailable: %s", e)
+        return None
+
+    doc_type = _sanitize_doc_type_from_path(path)
+    try:
+        compressed_content, compressed_tokens = _compress_or_truncate(
+            content, target_tokens, doc_type, project_root
+        )
+    except Exception as e:  # pragma: no cover - defensive, helper is fail-safe
+        logger.debug("Compression failed for %s: %s", path, e)
+        return None
+
+    # If compression didn't actually shrink the content (e.g. helper LLM
+    # echoed input, truncation floor hit), don't bother splicing — it
+    # adds annotation noise without saving budget. Drop instead.
+    if len(compressed_content) >= len(content):
+        logger.debug(
+            "Compression no-op for %s (%d → %d chars), falling through to drop",
+            path,
+            len(content),
+            len(compressed_content),
+        )
+        return None
+
+    annotated = (
+        f"[note: this file was compressed from ~{original_tokens} to "
+        f"~{compressed_tokens} tokens to fit prompt budget. Read the file "
+        f"directly via your file tools if you need exact content.]\n\n"
+        + compressed_content
+    )
+
+    new_block = _build_file_block_with_content(block, annotated)
+    if new_block is None:  # pragma: no cover - extraction succeeded so rebuild should too
+        return None
+
+    logger.info(
+        "Budget compress: shrank '%s' from %d to ~%d tokens",
+        path,
+        original_tokens,
+        len(annotated) // 4,
+    )
+
+    return prompt[: match.start()] + new_block + prompt[match.end() :]
+
+
+def _trim_source_context(
+    prompt: str,
+    current_tokens: int,
+    budget: int,
+    project_root: Path | None = None,
+) -> tuple[str, list[str], list[str]]:
+    """Trim or compress lowest-priority source files to fit the prompt budget.
 
     Source files in the <context> section are ordered by score (highest first).
-    We remove files from the end (lowest priority) until the estimated token
-    count is within budget.
+    We process from the end (lowest priority) until estimated tokens are
+    within budget. Each file's fate depends on its type:
+
+    - **Markdown** (``.md``/``.markdown``/``.mdx``): tries LLM compression
+      via ``_compress_or_truncate`` first (with disk cache). If compression
+      shrinks the file, splice the compressed version in place. If the
+      file is too small, compression is skipped with a debug log.
+    - **Source code** (everything else): always dropped. LLM summarization
+      of code can lose type signatures and exact API shapes, which is
+      unacceptable for dev_story / code_review. The model gets the file
+      via tool calls instead (elevated ToolCallGuard cap covers this).
+
+    Reverse iteration: we modify text only at-or-after the current match's
+    position, so earlier (still-pending) match offsets remain valid.
 
     Args:
         prompt: Full compiled prompt XML string.
         current_tokens: Current estimated token count (len/4).
         budget: Target token budget.
+        project_root: Project root for the compression disk cache. When
+            None, compression is skipped entirely (markdown files fall
+            through to the drop path — used by tests that don't want to
+            depend on the compression machinery).
 
     Returns:
-        Prompt with lowest-priority files removed, or unchanged if no
-        <context> section or if trimming isn't possible.
+        Tuple of ``(trimmed_prompt, removed_paths, compressed_paths)``.
+
+        - ``removed_paths``: files fully dropped from the prompt.
+        - ``compressed_paths``: markdown files compressed in place.
+
+        Callers feed BOTH lists into the ToolCallGuard's elevated-cap set,
+        because compressed files are still lossy summaries — the model
+        may need to read exact bytes via tools.
 
     """
     # Find all file blocks
     file_blocks = list(_FILE_BLOCK_RE.finditer(prompt))
     if not file_blocks:
-        return prompt
+        return prompt, [], []
 
-    # Remove files from the end (lowest priority) until within budget
     trimmed = prompt
-    removed_count = 0
+    removed_paths: list[str] = []
+    compressed_paths: list[str] = []
+
     for match in reversed(file_blocks):
         if len(trimmed) // 4 <= budget:
             break
+
         path = match.group(1)
-        # Remove the file block (and any surrounding newline)
+
+        # Markdown: try compression first.
+        is_markdown = path.lower().endswith(_MARKDOWN_EXTENSIONS)
+        if is_markdown and project_root is not None:
+            new_trimmed = _try_compress_markdown_file_block(
+                trimmed, match, path, project_root
+            )
+            if new_trimmed is not None:
+                trimmed = new_trimmed
+                compressed_paths.append(path)
+                continue
+
+        # Drop the file block (and any surrounding newline).
         start = match.start()
         end = match.end()
-        # Also remove trailing newline if present
         if end < len(trimmed) and trimmed[end] == "\n":
             end += 1
         trimmed = trimmed[:start] + trimmed[end:]
-        removed_count += 1
+        removed_paths.append(path)
         logger.info("Budget trim: removed source file '%s'", path)
 
-    if removed_count > 0:
+    if removed_paths or compressed_paths:
         new_tokens = len(trimmed) // 4
         logger.info(
-            "Trimmed %d source file(s): %d → %d estimated tokens (budget: %d)",
-            removed_count,
+            "Trimmed %d / compressed %d source file(s): %d → %d estimated tokens (budget: %d)",
+            len(removed_paths),
+            len(compressed_paths),
             current_tokens,
             new_tokens,
             budget,
         )
 
-    return trimmed
+    return trimmed, removed_paths, compressed_paths
 
 
 @dataclass
@@ -201,6 +446,41 @@ class BaseHandler(ABC):
         self.config = config
         self.project_path = project_path
         self._handler_config: HandlerConfig | None = None
+        # Files that were budget-trimmed out of the most recent compiled
+        # prompt. Reset on every compile_workflow_prompt call. invoke_provider
+        # uses this set to elevate the ToolCallGuard per-file cap so the
+        # model can read trimmed files via tools without hitting the base cap.
+        self._budget_trimmed_paths: set[str] = set()
+
+    def _record_budget_trimmed_paths(self, removed_paths: list[str]) -> None:
+        """Record paths trimmed from the prompt during budget enforcement.
+
+        Resolves each repo-relative path to a normalized realpath against
+        the project root so the lookup matches whatever path the model
+        passes to its file tools (which the guard normalizes the same way).
+
+        Args:
+            removed_paths: Paths from XML ``path="..."`` attributes as
+                captured by _trim_source_context.
+
+        """
+        import os
+
+        normalized: set[str] = set()
+        for raw in removed_paths:
+            try:
+                # Repo-relative or absolute — resolve against project root.
+                candidate = (self.project_path / raw).resolve(strict=False)
+                normalized.add(os.path.realpath(candidate))
+            except (OSError, ValueError) as exc:
+                logger.debug(
+                    "Could not normalize trimmed path %r: %s", raw, exc
+                )
+        self._budget_trimmed_paths = normalized
+
+    def _reset_budget_trimmed_paths(self) -> None:
+        """Clear trimmed-path tracking before a new compile."""
+        self._budget_trimmed_paths = set()
 
     @property
     @abstractmethod
@@ -382,6 +662,11 @@ class BaseHandler(ABC):
         # Convert phase_name to workflow name (e.g., create_story -> create-story)
         workflow_name = self.phase_name.replace("_", "-")
 
+        # Reset budget-trimmed path tracking — each compile starts fresh.
+        # invoke_provider() reads this set after compile to elevate the
+        # ToolCallGuard per-file cap for trimmed files.
+        self._reset_budget_trimmed_paths()
+
         # Check for debug links mode
         links_only = os.environ.get("BMAD_DEBUG_LINKS") == "1"
 
@@ -428,9 +713,17 @@ class BaseHandler(ABC):
                         expected_prompt_tokens,
                         workflow_budget,
                     )
-                    prompt = _trim_source_context(
-                        prompt, expected_prompt_tokens, workflow_budget
+                    prompt, removed_paths, compressed_paths = _trim_source_context(
+                        prompt,
+                        expected_prompt_tokens,
+                        workflow_budget,
+                        project_root=self.project_path,
                     )
+                    # Track BOTH dropped and compressed paths for elevated
+                    # ToolCallGuard cap. Compressed files are lossy summaries,
+                    # so the model may still need to read exact bytes via
+                    # tools — both cases warrant the higher per-file cap.
+                    self._record_budget_trimmed_paths(removed_paths + compressed_paths)
             except Exception:
                 # Config not loaded (e.g., in tests) - skip budget warning
                 pass
@@ -773,10 +1066,17 @@ class BaseHandler(ABC):
         )
 
         tg = self.config.tool_guard
+        # Pass budget-trimmed files into the guard so they get the elevated
+        # per-file cap. Empty set = no elevation, behavior unchanged.
+        elevated_paths = set(self._budget_trimmed_paths)
         guard = ToolCallGuard(
             max_total_calls=tg.max_total_calls,
             max_interactions_per_file=tg.max_interactions_per_file,
             max_calls_per_minute=tg.max_calls_per_minute,
+            elevated_file_paths=elevated_paths,
+            max_interactions_per_file_elevated=(
+                tg.max_interactions_per_file_trimmed
+            ),
         )
 
         while True:

--- a/src/bmad_assist/core/loop/handlers/base.py
+++ b/src/bmad_assist/core/loop/handlers/base.py
@@ -99,6 +99,66 @@ def check_for_edit_failures(stdout: str, target_hint: str | None = None) -> None
             # Continue checking for other patterns - don't break, log all failures
 
 
+# Regex to match <file ...>...</file> blocks within <context> section.
+# Files are ordered by priority (highest-scored first) so we remove from the end.
+_FILE_BLOCK_RE = re.compile(
+    r'<file\s+id="[^"]*"\s+path="([^"]*)"[^>]*>.*?</file>',
+    re.DOTALL,
+)
+
+
+def _trim_source_context(prompt: str, current_tokens: int, budget: int) -> str:
+    """Trim lowest-priority source files from compiled prompt to fit budget.
+
+    Source files in the <context> section are ordered by score (highest first).
+    We remove files from the end (lowest priority) until the estimated token
+    count is within budget.
+
+    Args:
+        prompt: Full compiled prompt XML string.
+        current_tokens: Current estimated token count (len/4).
+        budget: Target token budget.
+
+    Returns:
+        Prompt with lowest-priority files removed, or unchanged if no
+        <context> section or if trimming isn't possible.
+
+    """
+    # Find all file blocks
+    file_blocks = list(_FILE_BLOCK_RE.finditer(prompt))
+    if not file_blocks:
+        return prompt
+
+    # Remove files from the end (lowest priority) until within budget
+    trimmed = prompt
+    removed_count = 0
+    for match in reversed(file_blocks):
+        if len(trimmed) // 4 <= budget:
+            break
+        path = match.group(1)
+        # Remove the file block (and any surrounding newline)
+        start = match.start()
+        end = match.end()
+        # Also remove trailing newline if present
+        if end < len(trimmed) and trimmed[end] == "\n":
+            end += 1
+        trimmed = trimmed[:start] + trimmed[end:]
+        removed_count += 1
+        logger.info("Budget trim: removed source file '%s'", path)
+
+    if removed_count > 0:
+        new_tokens = len(trimmed) // 4
+        logger.info(
+            "Trimmed %d source file(s): %d → %d estimated tokens (budget: %d)",
+            removed_count,
+            current_tokens,
+            new_tokens,
+            budget,
+        )
+
+    return trimmed
+
+
 @dataclass
 class HandlerConfig:
     """Configuration loaded from handler YAML file.
@@ -358,15 +418,18 @@ class BaseHandler(ABC):
                 config = get_config()
                 workflow_budget = config.compiler.source_context.budgets.get_budget(workflow_name)
                 # Prompt is typically ~2x the token estimate due to XML overhead
-                expected_prompt_tokens = compiled.token_estimate * 2
+                expected_prompt_tokens = len(prompt) // 4
 
                 if expected_prompt_tokens > workflow_budget:
                     logger.warning(
                         "Prompt may exceed budget for %s: estimated %d tokens "
-                        "(config budget: %d). Consider reducing source context.",
+                        "(config budget: %d). Trimming lowest-priority source files.",
                         workflow_name,
                         expected_prompt_tokens,
                         workflow_budget,
+                    )
+                    prompt = _trim_source_context(
+                        prompt, expected_prompt_tokens, workflow_budget
                     )
             except Exception:
                 # Config not loaded (e.g., in tests) - skip budget warning

--- a/src/bmad_assist/core/loop/handlers/code_review_synthesis.py
+++ b/src/bmad_assist/core/loop/handlers/code_review_synthesis.py
@@ -41,6 +41,25 @@ from bmad_assist.validation.reports import extract_synthesis_report
 
 logger = logging.getLogger(__name__)
 
+# Reinforcement note appended to the prompt on retry when the first
+# attempt produced markers with empty content between them (observed
+# failure mode: model emits the synthesis report OUTSIDE the markers
+# as preamble/planning text, then emits empty START/END markers).
+_SYNTHESIS_MARKER_REINFORCEMENT = """
+
+---
+
+IMPORTANT — the previous attempt produced an EMPTY synthesis report
+(markers were present but the content between them was empty).
+
+Your final output MUST contain the synthesis report INSIDE the
+``<!-- CODE_REVIEW_SYNTHESIS_START -->`` and
+``<!-- CODE_REVIEW_SYNTHESIS_END -->`` markers. Do not emit planning
+text, implementation instructions, or preamble outside these markers.
+The complete synthesis report content must appear between START and
+END — nothing else matters.
+"""
+
 
 class CodeReviewSynthesisHandler(BaseHandler):
     """Handler for CODE_REVIEW_SYNTHESIS phase.
@@ -655,15 +674,73 @@ class CodeReviewSynthesisHandler(BaseHandler):
             # Record start time for benchmarking
             start_time = datetime.now(UTC)
 
-            # Invoke Master LLM with restricted tools (file manipulation only)
-            result = self.invoke_provider(
-                prompt, allowed_tools=["Read", "Edit", "Write", "Bash"]
-            )
+            # Invoke Master LLM with retry-on-short-output. Observed
+            # failure mode: model emits a long preamble ("Let me verify..."
+            # / "**Fix 1:** Implement...") OUTSIDE the START/END markers,
+            # then emits markers with empty or minimal content between
+            # them. First attempt uses the plain compiled prompt; on a
+            # short-output result the retry appends a reinforcement note
+            # explicitly telling the model to put the report INSIDE the
+            # markers. Single retry — if the second attempt also fails,
+            # we fail the phase with detailed marker-position diagnostics
+            # rather than save garbage.
+            min_synthesis_chars = 200
+            max_attempts = 2
+            result = None
+            extracted_synthesis = ""
+            end_time = start_time
 
-            # Record end time for benchmarking
-            end_time = datetime.now(UTC)
+            for attempt in range(1, max_attempts + 1):
+                attempt_prompt = prompt
+                if attempt > 1:
+                    attempt_prompt = prompt + _SYNTHESIS_MARKER_REINFORCEMENT
 
-            # Check for errors
+                result = self.invoke_provider(
+                    attempt_prompt,
+                    allowed_tools=["Read", "Edit", "Write", "Bash"],
+                )
+                end_time = datetime.now(UTC)
+
+                # Provider-level failure (non-zero exit, crash, etc.) —
+                # don't retry, fall through to the error branch.
+                if result.exit_code != 0:
+                    break
+
+                # Story 22.4 AC5: Check for Edit tool failures (best-effort logging)
+                check_for_edit_failures(result.stdout, target_hint="source files")
+
+                # Extract synthesis report using priority-based extraction
+                # 1. Markers, 2. Summary header, 3. Full content
+                extracted_synthesis = extract_synthesis_report(
+                    result.stdout,
+                    synthesis_type="code_review",
+                    termination_reason=getattr(result, "termination_reason", None),
+                )
+
+                if len(extracted_synthesis.strip()) >= min_synthesis_chars:
+                    break  # usable synthesis — proceed to save
+
+                # Short output; log and (if any attempts remain) retry.
+                if attempt < max_attempts:
+                    logger.warning(
+                        "Synthesis attempt %d/%d produced only %d chars "
+                        "(raw stdout %d chars). Markers likely bracket "
+                        "empty content. Retrying with reinforcement note.",
+                        attempt,
+                        max_attempts,
+                        len(extracted_synthesis.strip()),
+                        len(result.stdout),
+                    )
+
+            # Check for errors (after retry loop)
+            if result is None:
+                # Defensive — should be unreachable (loop always runs ≥1
+                # iteration and assigns result).
+                return PhaseResult.fail(
+                    "Code review synthesis failed: provider invocation "
+                    "never completed."
+                )
+
             if result.exit_code != 0:
                 error_msg = result.stderr or f"Master LLM exited with code {result.exit_code}"
                 logger.warning(
@@ -679,35 +756,55 @@ class CodeReviewSynthesisHandler(BaseHandler):
                     len(result.stdout),
                 )
 
-                # Story 22.4 AC5: Check for Edit tool failures (best-effort logging)
-                check_for_edit_failures(result.stdout, target_hint="source files")
-
-                # Extract synthesis report using priority-based extraction
-                # 1. Markers, 2. Summary header, 3. Full content
-                extracted_synthesis = extract_synthesis_report(
-                    result.stdout,
-                    synthesis_type="code_review",
-                    termination_reason=getattr(result, "termination_reason", None),
-                )
-
                 # Guard against silent provider failure: if provider returns
-                # exit_code=0 but empty/minimal output, synthesis is useless.
-                min_synthesis_chars = 200
+                # exit_code=0 but empty/minimal output (even after retry),
+                # synthesis is useless. Log detailed diagnostics so the
+                # operator can see WHERE the markers were in the raw output
+                # and decide whether to switch provider / adjust prompt.
                 if len(extracted_synthesis.strip()) < min_synthesis_chars:
+                    start_marker = "<!-- CODE_REVIEW_SYNTHESIS_START -->"
+                    end_marker = "<!-- CODE_REVIEW_SYNTHESIS_END -->"
+                    raw_stdout = result.stdout or ""
+                    start_pos = raw_stdout.find(start_marker)
+                    end_pos = raw_stdout.find(end_marker)
+                    if start_pos != -1 and end_pos != -1:
+                        marker_gap = end_pos - start_pos - len(start_marker)
+                        marker_diag = (
+                            f"START@{start_pos}, END@{end_pos}, "
+                            f"content between={marker_gap} chars"
+                        )
+                    else:
+                        marker_diag = (
+                            f"START@{'found' if start_pos != -1 else 'missing'}, "
+                            f"END@{'found' if end_pos != -1 else 'missing'}"
+                        )
+                    head_preview = (
+                        raw_stdout[:400] if raw_stdout else "(empty)"
+                    )
+                    tail_preview = (
+                        raw_stdout[-400:] if len(raw_stdout) > 800 else ""
+                    )
                     logger.error(
-                        "Code review synthesis output too short (%d chars, min %d). "
-                        "Provider returned exit_code=0 but produced no meaningful synthesis. "
-                        "Raw stdout (%d chars): %.500s",
+                        "Code review synthesis output too short "
+                        "(%d chars, min %d) after %d attempts. "
+                        "Markers: %s. Raw stdout (%d chars). "
+                        "Head: %.400s ... Tail: %.400s",
                         len(extracted_synthesis.strip()),
                         min_synthesis_chars,
-                        len(result.stdout),
-                        result.stdout[:500] if result.stdout else "(empty)",
+                        max_attempts,
+                        marker_diag,
+                        len(raw_stdout),
+                        head_preview,
+                        tail_preview,
                     )
                     return PhaseResult.fail(
-                        f"Code review synthesis failed: provider returned empty/minimal output "
+                        f"Code review synthesis failed: provider returned "
+                        f"empty/minimal output after {max_attempts} attempts "
                         f"({len(extracted_synthesis.strip())} chars, "
-                        f"duration={result.duration_ms}ms). "
-                        f"Check provider config and model availability."
+                        f"duration={result.duration_ms}ms, "
+                        f"markers: {marker_diag}). "
+                        f"Model likely emitted content outside the START/END "
+                        f"markers. Check provider config and model capability."
                     )
 
                 # Save synthesis report to code-reviews directory

--- a/src/bmad_assist/core/loop/handlers/code_review_synthesis.py
+++ b/src/bmad_assist/core/loop/handlers/code_review_synthesis.py
@@ -685,7 +685,9 @@ class CodeReviewSynthesisHandler(BaseHandler):
                 # Extract synthesis report using priority-based extraction
                 # 1. Markers, 2. Summary header, 3. Full content
                 extracted_synthesis = extract_synthesis_report(
-                    result.stdout, synthesis_type="code_review"
+                    result.stdout,
+                    synthesis_type="code_review",
+                    termination_reason=getattr(result, "termination_reason", None),
                 )
 
                 # Guard against silent provider failure: if provider returns

--- a/src/bmad_assist/core/loop/handlers/validate_story.py
+++ b/src/bmad_assist/core/loop/handlers/validate_story.py
@@ -88,13 +88,15 @@ class ValidateStoryHandler(BaseHandler):
             if epic_num is None or story_num_str is None:
                 return PhaseResult.fail("Cannot validate: missing epic_num or story_num in state")
 
-            _m = re.match(r"(\d+)", story_num_str)
-            story_num = int(_m.group(1)) if _m else 1
+            story_num: int | str = story_num_str
+            _m = re.match(r"(\d+)$", story_num_str)
+            if _m:
+                story_num = int(_m.group(1))
 
             logger.info(
                 "Starting validation phase for story %s.%s",
                 epic_num,
-                story_num,
+                story_num_str,
             )
 
             # Pre-compile workflow patches BEFORE entering the async event loop.

--- a/src/bmad_assist/core/loop/handlers/validate_story.py
+++ b/src/bmad_assist/core/loop/handlers/validate_story.py
@@ -14,6 +14,7 @@ This handler orchestrates:
 """
 
 import logging
+import re
 from typing import Any
 
 from bmad_assist.core.loop.handlers.base import BaseHandler
@@ -87,7 +88,8 @@ class ValidateStoryHandler(BaseHandler):
             if epic_num is None or story_num_str is None:
                 return PhaseResult.fail("Cannot validate: missing epic_num or story_num in state")
 
-            story_num = int(story_num_str)
+            _m = re.match(r"(\d+)", story_num_str)
+            story_num = int(_m.group(1)) if _m else 1
 
             logger.info(
                 "Starting validation phase for story %s.%s",

--- a/src/bmad_assist/core/loop/handlers/validate_story_synthesis.py
+++ b/src/bmad_assist/core/loop/handlers/validate_story_synthesis.py
@@ -18,6 +18,7 @@ has write permission to modify the story file.
 """
 
 import logging
+import re
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -135,7 +136,8 @@ class ValidateStorySynthesisHandler(BaseHandler):
         if epic_num is None or story_num_str is None:
             raise ConfigError("Cannot synthesize: missing epic_num or story_num in state")
 
-        story_num = int(story_num_str)
+        _m = re.match(r"(\d+)", story_num_str)
+        story_num = int(_m.group(1)) if _m else 1
 
         # Get session_id for loading validations
         session_id = self._get_session_id_from_state(state)
@@ -402,7 +404,8 @@ class ValidateStorySynthesisHandler(BaseHandler):
             if epic_num is None or story_num_str is None:
                 raise ConfigError("Cannot synthesize: missing epic_num or story_num in state")
 
-            story_num = int(story_num_str)
+            _m = re.match(r"(\d+)", story_num_str)
+            story_num = int(_m.group(1)) if _m else 1
 
             # Get session_id and load validations for report saving
             session_id = self._get_session_id_from_state(state)
@@ -460,7 +463,9 @@ class ValidateStorySynthesisHandler(BaseHandler):
                 # Extract synthesis report using priority-based extraction
                 # 1. Markers, 2. Summary header, 3. Full content
                 extracted_synthesis = extract_synthesis_report(
-                    result.stdout, synthesis_type="validation"
+                    result.stdout,
+                    synthesis_type="validation",
+                    termination_reason=getattr(result, "termination_reason", None),
                 )
 
                 # Guard against silent provider failure: if provider returns

--- a/src/bmad_assist/core/loop/handlers/validate_story_synthesis.py
+++ b/src/bmad_assist/core/loop/handlers/validate_story_synthesis.py
@@ -616,7 +616,7 @@ class ValidateStorySynthesisHandler(BaseHandler):
         self,
         synthesis_output: str,
         epic_num: EpicId,
-        story_num: int,
+        story_num: int | str,
         story_title: str,
         start_time: datetime,
         end_time: datetime,

--- a/src/bmad_assist/core/loop/handlers/validate_story_synthesis.py
+++ b/src/bmad_assist/core/loop/handlers/validate_story_synthesis.py
@@ -136,8 +136,10 @@ class ValidateStorySynthesisHandler(BaseHandler):
         if epic_num is None or story_num_str is None:
             raise ConfigError("Cannot synthesize: missing epic_num or story_num in state")
 
-        _m = re.match(r"(\d+)", story_num_str)
-        story_num = int(_m.group(1)) if _m else 1
+        story_num: int | str = story_num_str
+        _m = re.match(r"(\d+)$", story_num_str)
+        if _m:
+            story_num = int(_m.group(1))
 
         # Get session_id for loading validations
         session_id = self._get_session_id_from_state(state)
@@ -404,8 +406,10 @@ class ValidateStorySynthesisHandler(BaseHandler):
             if epic_num is None or story_num_str is None:
                 raise ConfigError("Cannot synthesize: missing epic_num or story_num in state")
 
-            _m = re.match(r"(\d+)", story_num_str)
-            story_num = int(_m.group(1)) if _m else 1
+            story_num: int | str = story_num_str
+            _m = re.match(r"(\d+)$", story_num_str)
+            if _m:
+                story_num = int(_m.group(1))
 
             # Get session_id and load validations for report saving
             session_id = self._get_session_id_from_state(state)

--- a/src/bmad_assist/core/loop/interactive.py
+++ b/src/bmad_assist/core/loop/interactive.py
@@ -27,6 +27,10 @@ _skip_story_prompts: bool = False
 # Global flag to enable backfill mode (implement missed stories before forward progress)
 _backfill_enabled: bool = False
 
+# The forward frontier story — set when backfill starts, used as the fixed
+# reference point for gap detection throughout the backfill pass.
+_backfill_frontier: str | None = None
+
 
 def set_non_interactive(enabled: bool) -> None:
     """Set the global non-interactive mode.
@@ -84,6 +88,31 @@ def set_backfill_enabled(enabled: bool) -> None:
 def is_backfill_enabled() -> bool:
     """Check if backfill mode is enabled."""
     return _backfill_enabled
+
+
+def set_backfill_frontier(story: str | None) -> None:
+    """Set or clear the backfill forward frontier story.
+
+    The frontier is the story that was current when backfill started.
+    Gap detection always uses this as the reference point, not the
+    currently-executing backfill story.
+
+    Args:
+        story: Story ID like "10.6", or None to clear.
+
+    """
+    global _backfill_frontier
+    _backfill_frontier = story
+
+
+def get_backfill_frontier() -> str | None:
+    """Get the backfill forward frontier story, or None if not in backfill."""
+    return _backfill_frontier
+
+
+def is_in_backfill() -> bool:
+    """Check if currently executing backfill stories (frontier is set)."""
+    return _backfill_frontier is not None
 
 
 def prompt_continuation(message: str) -> bool:

--- a/src/bmad_assist/core/loop/interactive.py
+++ b/src/bmad_assist/core/loop/interactive.py
@@ -24,6 +24,9 @@ _force_non_interactive: bool = False
 # Global flag to skip story boundary prompts but keep epic boundary prompts
 _skip_story_prompts: bool = False
 
+# Global flag to enable backfill mode (implement missed stories before forward progress)
+_backfill_enabled: bool = False
+
 
 def set_non_interactive(enabled: bool) -> None:
     """Set the global non-interactive mode.
@@ -61,6 +64,26 @@ def set_skip_story_prompts(enabled: bool) -> None:
 def is_skip_story_prompts() -> bool:
     """Check if story boundary prompts should be skipped."""
     return _skip_story_prompts
+
+
+def set_backfill_enabled(enabled: bool) -> None:
+    """Set the global backfill mode.
+
+    When enabled, after completing the current story the runner scans
+    for missed/skipped stories before the current position and implements
+    them before continuing forward.
+
+    Args:
+        enabled: True to enable backfill mode.
+
+    """
+    global _backfill_enabled
+    _backfill_enabled = enabled
+
+
+def is_backfill_enabled() -> bool:
+    """Check if backfill mode is enabled."""
+    return _backfill_enabled
 
 
 def prompt_continuation(message: str) -> bool:

--- a/src/bmad_assist/core/loop/runner.py
+++ b/src/bmad_assist/core/loop/runner.py
@@ -682,6 +682,7 @@ def _check_backfill(
             "current_story": next_story,
             "current_phase": Phase.CREATE_STORY,
             "code_review_rework_count": 0,
+            "epic_setup_complete": True,  # Skip setup for backfill epics
             "updated_at": now,
         }
     )

--- a/src/bmad_assist/core/loop/runner.py
+++ b/src/bmad_assist/core/loop/runner.py
@@ -1562,6 +1562,8 @@ def _run_loop_body(
                 # This runs for BOTH epic-complete and non-epic-complete cases,
                 # and suppresses epic teardown/retrospective during backfill.
                 if is_backfill_enabled() and state.current_story:
+                    # Remember frontier BEFORE check (it clears on completion)
+                    frontier_before = get_backfill_frontier()
                     backfill_next = _check_backfill(
                         new_state, state.current_story, epic_list,
                         epic_stories_loader, project_path, state_path,
@@ -1589,6 +1591,24 @@ def _run_loop_body(
                             story_title=_get_story_title(project_path, state.current_story or ""),
                         )
                         continue  # Execute backfill story
+
+                    # Backfill just completed — if this epic was a backfilled
+                    # epic (not the forward epic), skip its teardown too
+                    if is_epic_complete and frontier_before is not None:
+                        frontier_epic = frontier_before.split(".")[0]
+                        current_epic_str = str(state.current_epic)
+                        if current_epic_str != frontier_epic:
+                            logger.info(
+                                "Backfill complete: skipping epic %s teardown "
+                                "(backfilled epic, forward epic is %s)",
+                                state.current_epic,
+                                frontier_epic,
+                            )
+                            # Advance to forward position (next story after frontier)
+                            state = new_state
+                            start_story_timing(state)
+                            _invoke_sprint_sync(state, project_path)
+                            continue
 
                 if is_epic_complete:
                     # Run all epic teardown phases (retrospective, qa_plan_*, etc.)

--- a/src/bmad_assist/core/loop/runner.py
+++ b/src/bmad_assist/core/loop/runner.py
@@ -62,8 +62,10 @@ from bmad_assist.core.loop.helpers import (
 )
 from bmad_assist.core.loop.interactive import (
     checkpoint_and_prompt,
+    get_backfill_frontier,
     is_backfill_enabled,
     is_skip_story_prompts,
+    set_backfill_frontier,
 )
 from bmad_assist.core.loop.locking import _running_lock
 from bmad_assist.core.loop.notifications import _dispatch_event
@@ -606,6 +608,11 @@ def _check_backfill(
     gap stories (missed/skipped) that come before the forward frontier
     and redirects the runner to the first one.
 
+    The forward frontier is set once (the story that was current when
+    backfill first activates) and remains fixed throughout the backfill
+    pass. This prevents the frontier from shifting as each backfill
+    story completes.
+
     During backfill:
     - No epic teardown/retrospective is triggered
     - No epic-boundary prompts are shown
@@ -628,6 +635,14 @@ def _check_backfill(
     from bmad_assist.core.loop.backfill import detect_backfill_stories
     from bmad_assist.core.paths import get_paths
 
+    # Set frontier on first backfill activation — this is the fixed
+    # reference point for the entire backfill pass
+    frontier = get_backfill_frontier()
+    if frontier is None:
+        frontier = just_completed_story
+        set_backfill_frontier(frontier)
+        logger.info("Backfill: frontier set to %s", frontier)
+
     # Load sprint statuses for deferred detection
     try:
         paths = get_paths()
@@ -637,15 +652,19 @@ def _check_backfill(
 
     sprint_statuses = _load_sprint_status(bmad_path) or {}
 
+    # Always use the fixed frontier, not the just-completed story
     gaps = detect_backfill_stories(
         completed_stories=list(state.completed_stories),
-        current_story=just_completed_story,
+        current_story=frontier,
         epic_list=epic_list,
         epic_stories_loader=epic_stories_loader,
         sprint_statuses=sprint_statuses,
     )
 
     if not gaps:
+        # Backfill complete — clear frontier, resume normal execution
+        set_backfill_frontier(None)
+        logger.info("Backfill complete: all gap stories implemented, resuming forward execution")
         return None
 
     # Redirect to first gap story
@@ -669,7 +688,7 @@ def _check_backfill(
     save_state(backfill_state, state_path)
 
     logger.info(
-        "Backfill: %d gap stories detected, next: %s (epic %s). "
+        "Backfill: %d gap stories remaining, next: %s (epic %s). "
         "Remaining: %s",
         len(gaps),
         next_story,
@@ -1538,14 +1557,22 @@ def _run_loop_body(
 
                 new_state, is_epic_complete = handle_story_completion(state, epic_stories, state_path)
 
-                # Backfill check: before normal advancement, see if there are
-                # missed stories that come before the forward frontier.
+                # Backfill check: before normal advancement or epic teardown,
+                # see if there are missed stories before the forward frontier.
+                # This runs for BOTH epic-complete and non-epic-complete cases,
+                # and suppresses epic teardown/retrospective during backfill.
                 if is_backfill_enabled() and state.current_story:
                     backfill_next = _check_backfill(
                         new_state, state.current_story, epic_list,
                         epic_stories_loader, project_path, state_path,
                     )
                     if backfill_next is not None:
+                        if is_epic_complete:
+                            logger.info(
+                                "Backfill: skipping epic %s teardown/retrospective "
+                                "(backfill stories pending)",
+                                state.current_epic,
+                            )
                         state = backfill_next
                         start_story_timing(state)
                         _invoke_sprint_sync(state, project_path)

--- a/src/bmad_assist/core/loop/runner.py
+++ b/src/bmad_assist/core/loop/runner.py
@@ -1074,6 +1074,23 @@ def _run_loop_body(
                 )
                 save_state(state, state_path)
 
+        # Safety check: if current phase is a setup/teardown phase (not a story phase),
+        # the state was corrupted (e.g., killed during TEA setup). Reset to CREATE_STORY.
+        story_phase_set_check = {Phase(p) for p in loop_config.story}
+        if state.current_phase and state.current_phase not in story_phase_set_check:
+            logger.warning(
+                "State has non-story phase %s (likely interrupted during setup/teardown). "
+                "Resetting to CREATE_STORY.",
+                state.current_phase.name,
+            )
+            state = state.model_copy(
+                update={
+                    "current_phase": Phase(loop_config.story[0]),
+                    "updated_at": datetime.now(UTC).replace(tzinfo=None),
+                }
+            )
+            save_state(state, state_path)
+
         # Main loop - runs until project complete or guardian halt
         while True:
             # Dashboard integration: Check for log level changes from control file

--- a/src/bmad_assist/core/loop/runner.py
+++ b/src/bmad_assist/core/loop/runner.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import contextlib
 import logging
 import os
+import re
 import sys
 import time
 from collections.abc import Callable
@@ -59,7 +60,11 @@ from bmad_assist.core.loop.helpers import (
     _get_story_title,
     _print_phase_banner,
 )
-from bmad_assist.core.loop.interactive import checkpoint_and_prompt, is_skip_story_prompts
+from bmad_assist.core.loop.interactive import (
+    checkpoint_and_prompt,
+    is_backfill_enabled,
+    is_skip_story_prompts,
+)
 from bmad_assist.core.loop.locking import _running_lock
 from bmad_assist.core.loop.notifications import _dispatch_event
 from bmad_assist.core.loop.run_tracking import (
@@ -587,6 +592,94 @@ def _get_stop_exit_reason(cancel_ctx: CancellationContext | None) -> LoopExitRea
     return _get_interrupt_exit_reason()
 
 
+def _check_backfill(
+    state: State,
+    just_completed_story: str,
+    epic_list: list[EpicId],
+    epic_stories_loader: Callable[[EpicId], list[str]],
+    project_path: Path,
+    state_path: Path,
+) -> State | None:
+    """Check for backfill stories and return updated state if found.
+
+    Called after story completion when --backfill is enabled. Detects
+    gap stories (missed/skipped) that come before the forward frontier
+    and redirects the runner to the first one.
+
+    During backfill:
+    - No epic teardown/retrospective is triggered
+    - No epic-boundary prompts are shown
+    - Epic switching happens silently (on current git branch)
+
+    Args:
+        state: Current state after story completion.
+        just_completed_story: The story that was just completed.
+        epic_list: All epic IDs.
+        epic_stories_loader: Loader for epic story lists.
+        project_path: Project root path.
+        state_path: Path to state file.
+
+    Returns:
+        New State pointing to the first backfill story, or None if
+        no gaps found (normal advancement should proceed).
+
+    """
+    from bmad_assist.bmad.state_reader import _load_sprint_status
+    from bmad_assist.core.loop.backfill import detect_backfill_stories
+    from bmad_assist.core.paths import get_paths
+
+    # Load sprint statuses for deferred detection
+    try:
+        paths = get_paths()
+        bmad_path = paths.project_knowledge
+    except RuntimeError:
+        bmad_path = project_path / "_bmad-output"
+
+    sprint_statuses = _load_sprint_status(bmad_path) or {}
+
+    gaps = detect_backfill_stories(
+        completed_stories=list(state.completed_stories),
+        current_story=just_completed_story,
+        epic_list=epic_list,
+        epic_stories_loader=epic_stories_loader,
+        sprint_statuses=sprint_statuses,
+    )
+
+    if not gaps:
+        return None
+
+    # Redirect to first gap story
+    next_story = gaps[0]
+    next_epic_part = next_story.split(".")[0]
+    try:
+        next_epic: EpicId = int(next_epic_part)
+    except ValueError:
+        next_epic = next_epic_part
+
+    now = datetime.now(UTC).replace(tzinfo=None)
+    backfill_state = state.model_copy(
+        update={
+            "current_epic": next_epic,
+            "current_story": next_story,
+            "current_phase": Phase.CREATE_STORY,
+            "code_review_rework_count": 0,
+            "updated_at": now,
+        }
+    )
+    save_state(backfill_state, state_path)
+
+    logger.info(
+        "Backfill: %d gap stories detected, next: %s (epic %s). "
+        "Remaining: %s",
+        len(gaps),
+        next_story,
+        next_epic,
+        ", ".join(gaps[1:5]) + ("..." if len(gaps) > 5 else ""),
+    )
+
+    return backfill_state
+
+
 def _run_loop_body(
     config: Config,
     project_path: Path,
@@ -748,7 +841,9 @@ def _run_loop_body(
         # Story 22.9: Emit dashboard story_transition and workflow_status events
         sequence_id += 1
         epic_num = int(state.current_epic) if state.current_epic else 1
-        story_num = int(first_story.split(".")[-1])
+        _story_part = first_story.split(".")[-1]
+        _m = re.match(r"(\d+)", _story_part)
+        story_num = int(_m.group(1)) if _m else 1
         story_title = (
             first_story.split(".")[-1].replace("-", " ") if "." in first_story else first_story
         )
@@ -1442,6 +1537,31 @@ def _run_loop_body(
                     )
 
                 new_state, is_epic_complete = handle_story_completion(state, epic_stories, state_path)
+
+                # Backfill check: before normal advancement, see if there are
+                # missed stories that come before the forward frontier.
+                if is_backfill_enabled() and state.current_story:
+                    backfill_next = _check_backfill(
+                        new_state, state.current_story, epic_list,
+                        epic_stories_loader, project_path, state_path,
+                    )
+                    if backfill_next is not None:
+                        state = backfill_next
+                        start_story_timing(state)
+                        _invoke_sprint_sync(state, project_path)
+                        logger.info(
+                            "Backfill: advancing to story %s (epic %s)",
+                            state.current_story,
+                            state.current_epic,
+                        )
+                        _dispatch_event(
+                            "story_started",
+                            project_path,
+                            state,
+                            phase=state.current_phase.name if state.current_phase else "CREATE_STORY",
+                            story_title=_get_story_title(project_path, state.current_story or ""),
+                        )
+                        continue  # Execute backfill story
 
                 if is_epic_complete:
                     # Run all epic teardown phases (retrospective, qa_plan_*, etc.)

--- a/src/bmad_assist/core/loop/runner.py
+++ b/src/bmad_assist/core/loop/runner.py
@@ -1074,12 +1074,23 @@ def _run_loop_body(
                 )
                 save_state(state, state_path)
 
-        # Safety check: if current phase is a setup/teardown phase (not a story phase),
-        # the state was corrupted (e.g., killed during TEA setup). Reset to CREATE_STORY.
-        story_phase_set_check = {Phase(p) for p in loop_config.story}
-        if state.current_phase and state.current_phase not in story_phase_set_check:
+        # Safety check: if current phase is an epic_setup phase, the state was
+        # corrupted (e.g., killed during TEA setup) — main loop can't advance
+        # from a setup phase, so reset to CREATE_STORY.
+        #
+        # NOTE: teardown phases (RETROSPECTIVE, TRACE, etc.) are legitimate
+        # resume points after the last story of an epic completes. The main
+        # loop dispatches them via handle_story/epic_completion when it sees
+        # them, so we MUST NOT reset them — doing so would skip teardown
+        # entirely and mis-restart the just-finished epic from CREATE_STORY.
+        epic_setup_phase_set = (
+            {Phase(p) for p in loop_config.epic_setup}
+            if loop_config.epic_setup
+            else set()
+        )
+        if state.current_phase and state.current_phase in epic_setup_phase_set:
             logger.warning(
-                "State has non-story phase %s (likely interrupted during setup/teardown). "
+                "State has setup phase %s (likely interrupted during epic setup). "
                 "Resetting to CREATE_STORY.",
                 state.current_phase.name,
             )

--- a/src/bmad_assist/core/project_setup.py
+++ b/src/bmad_assist/core/project_setup.py
@@ -530,9 +530,14 @@ def copy_bundled_workflows(
                         result.copied.append(name)
                         console.print(f"  [green]Overwrote:[/green] {name}")
                 elif decision == OverwriteDecision.SKIP:
-                    # Skip all
+                    # Skip only workflows with actual file-level differences;
+                    # directories that differed structurally but had no content
+                    # changes go to unchanged.
                     for name, _, _ in differing_workflows:
-                        result.skipped.append(name)
+                        if name in workflow_files_map:
+                            result.skipped.append(name)
+                        else:
+                            result.unchanged.append(name)
                 elif decision == OverwriteDecision.INTERACTIVE:
                     # Interactive mode - prompt per file
                     apply_all: SingleOverwriteDecision | None = None

--- a/src/bmad_assist/core/retry.py
+++ b/src/bmad_assist/core/retry.py
@@ -24,6 +24,7 @@ def invoke_with_timeout_retry(
     phase_name: str,
     fallback_invoke_fn: Callable[..., T] | None = None,
     fallback_timeout_retries: int | None = None,
+    fallback_timeout: int | None = None,
     **kwargs: Any,
 ) -> T:
     """Invoke provider function with timeout retry logic.
@@ -42,6 +43,9 @@ def invoke_with_timeout_retry(
         fallback_invoke_fn: Optional fallback callable (e.g., subprocess provider).
             If primary fails after retries, fallback is invoked with reset retry count.
         fallback_timeout_retries: Retry count for fallback (defaults to timeout_retries).
+        fallback_timeout: Explicit timeout for fallback provider (seconds).
+            None = use 1.5x the primary timeout (auto-scaling).
+            Useful when fallback provider needs more time than primary.
         **kwargs: Arguments to pass to invoke_fn and fallback_invoke_fn.
 
     Returns:
@@ -91,12 +95,17 @@ def invoke_with_timeout_retry(
                         phase_name,
                         timeout_attempt,
                     )
+                    effective_fb_timeout = fallback_timeout
+                    if effective_fb_timeout is None:
+                        original_timeout = kwargs.get("timeout", 3600)
+                        effective_fb_timeout = int(original_timeout * 1.5)
+                    fb_kwargs = {**kwargs, "timeout": effective_fb_timeout}
                     return invoke_with_timeout_retry(
                         fallback_invoke_fn,
                         timeout_retries=fallback_timeout_retries if fallback_timeout_retries is not None else timeout_retries,
                         phase_name=f"{phase_name}(fallback)",
                         fallback_invoke_fn=None,  # No second fallback
-                        **kwargs,
+                        **fb_kwargs,
                     )
 
                 # No fallback - raise error

--- a/src/bmad_assist/dashboard/schemas.py
+++ b/src/bmad_assist/dashboard/schemas.py
@@ -85,7 +85,7 @@ class WorkflowStatusData(BaseModel):
     """
 
     current_epic: int | str = Field(...)
-    current_story: str = Field(..., pattern=r"^[\w-]+\.\d+$")
+    current_story: str = Field(..., pattern=r"^[\w-]+\.[\w]+(?:-[\w]+)*$")
     current_phase: Literal[
         "CREATE_STORY",
         "VALIDATE_STORY",
@@ -155,7 +155,7 @@ class StoryStatusData(BaseModel):
     """
 
     epic_num: int | str = Field(...)
-    story_num: int = Field(..., ge=1)
+    story_num: int | str = Field(...)
     story_id: str = Field(..., pattern=r"^[\w-]+-\d+-[\w-]+$")
     status: Literal["backlog", "ready-for-dev", "in-progress", "review", "done"]
     previous_status: Literal["backlog", "ready-for-dev", "in-progress", "review", "done"] | None = (
@@ -211,7 +211,7 @@ class StoryTransitionData(BaseModel):
 
     action: Literal["started", "completed"]
     epic_num: int | str = Field(...)
-    story_num: int = Field(..., ge=1)
+    story_num: int | str = Field(...)
     story_id: str = Field(..., pattern=r"^[\w-]+-\d+-[\w-]+$")
     story_title: str = Field(..., min_length=1)
 
@@ -384,7 +384,7 @@ def create_story_status(
     run_id: str,
     sequence_id: int,
     epic_num: int | str,
-    story_num: int,
+    story_num: int | str,
     story_id: str,
     status: str,
     previous_status: str | None = None,
@@ -424,7 +424,7 @@ def create_story_transition(
     sequence_id: int,
     action: str,
     epic_num: int | str,
-    story_num: int,
+    story_num: int | str,
     story_id: str,
     story_title: str,
 ) -> StoryTransitionEvent:

--- a/src/bmad_assist/dashboard/server.py
+++ b/src/bmad_assist/dashboard/server.py
@@ -12,6 +12,7 @@ Public API:
 """
 
 import asyncio
+import collections.abc
 import contextlib
 import logging
 import os
@@ -907,8 +908,7 @@ class DashboardServer:
             debug=True,
             routes=routes,
             middleware=middleware,
-            on_startup=[self._on_startup],
-            on_shutdown=[self._on_shutdown],
+            lifespan=self._lifespan,
         )
 
         # Store server reference in app state
@@ -916,6 +916,15 @@ class DashboardServer:
 
         self._app = app
         return app
+
+    @contextlib.asynccontextmanager
+    async def _lifespan(self, app: Starlette) -> collections.abc.AsyncIterator[None]:
+        """Starlette lifespan context manager (replaces on_startup/on_shutdown)."""
+        await self._on_startup()
+        try:
+            yield
+        finally:
+            await self._on_shutdown()
 
     async def _on_startup(self) -> None:
         """Handle server startup."""

--- a/src/bmad_assist/git/committer.py
+++ b/src/bmad_assist/git/committer.py
@@ -41,6 +41,44 @@ def is_git_enabled() -> bool:
     return os.environ.get("BMAD_GIT_COMMIT") == "1"
 
 
+# Default threshold for "large commit" warnings. Override via the
+# ``BMAD_GIT_WARN_LARGE_COMMITS_THRESHOLD`` env var. Set to 0 to disable
+# the warning entirely.
+_DEFAULT_LARGE_COMMIT_THRESHOLD = 100
+
+
+def _get_large_commit_threshold() -> int:
+    """Resolve the large-commit warning threshold from env, fall back safely.
+
+    Returns 0 when disabled (env var explicitly 0), the configured value
+    otherwise, or the default on invalid input.
+    """
+    raw = os.environ.get("BMAD_GIT_WARN_LARGE_COMMITS_THRESHOLD")
+    if raw is None:
+        return _DEFAULT_LARGE_COMMIT_THRESHOLD
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning(
+            "Invalid BMAD_GIT_WARN_LARGE_COMMITS_THRESHOLD=%r (expected int), "
+            "using default %d",
+            raw,
+            _DEFAULT_LARGE_COMMIT_THRESHOLD,
+        )
+        return _DEFAULT_LARGE_COMMIT_THRESHOLD
+    return max(0, value)
+
+
+def _should_force_stage_all() -> bool:
+    """Escape hatch: force legacy ``git add -A`` behavior when set.
+
+    Preserves the original unconditional-stage-all semantics for users
+    who rely on it (e.g. workflows that create files outside the
+    excluded-prefix filter and still want them auto-committed).
+    """
+    return os.environ.get("BMAD_GIT_STAGE_ALL") == "1"
+
+
 def should_commit_phase(phase: Phase | None) -> bool:
     """Check if the given phase should trigger a commit."""
     return phase in COMMIT_PHASES
@@ -238,17 +276,39 @@ def _generate_conventional_message(
     return message
 
 
-def stage_all_changes(project_path: Path) -> bool:
-    """Stage all modified files for commit.
+def stage_all_changes(
+    project_path: Path,
+    paths: list[str] | None = None,
+) -> bool:
+    """Stage modified files for commit.
 
     Args:
         project_path: Path to git repository.
+        paths: Optional explicit list of repo-relative paths to stage.
+            When provided (and ``BMAD_GIT_STAGE_ALL`` is NOT set), runs
+            ``git add -- <paths>`` to stage only those files — aligning
+            with whatever filter the caller applied (typically
+            :func:`get_modified_files`' exclusion list). When ``paths``
+            is None OR the escape hatch is set, falls back to
+            ``git add -A`` (legacy "stage everything" behavior).
+            Empty list is treated as "nothing to stage" — returns True.
 
     Returns:
-        True if staging succeeded.
+        True if staging succeeded or was a no-op (empty path list).
 
     """
-    exit_code, _, stderr = _run_git(["add", "-A"], project_path)
+    force_all = _should_force_stage_all()
+
+    if paths is not None and not force_all:
+        if not paths:
+            # Nothing to stage — not an error. commit_changes() below
+            # will no-op via its "nothing to commit" path.
+            return True
+        # ``--`` separator protects against paths that start with ``-``.
+        exit_code, _, stderr = _run_git(["add", "--", *paths], project_path)
+    else:
+        exit_code, _, stderr = _run_git(["add", "-A"], project_path)
+
     if exit_code != 0:
         logger.error("Failed to stage changes: %s", stderr)
         return False
@@ -530,6 +590,27 @@ def auto_commit_phase(
         phase.value if phase else "unknown",
     )
 
+    # Approach A (safety net): warn when the number of files to commit
+    # crosses a threshold. Catches the symptom of "branch created from
+    # a dirty working tree captured 1000+ unrelated files" without
+    # changing staging behavior. Users see the warning and can decide
+    # whether to investigate before the commit goes through.
+    threshold = _get_large_commit_threshold()
+    if threshold > 0 and len(modified_files) > threshold:
+        preview = modified_files[:5]
+        logger.warning(
+            "Large auto-commit detected: %d files exceed threshold %d "
+            "(phase=%s). Sample: %s%s. If this is unexpected, check for "
+            "unrelated changes staged on this branch (e.g. leftover work "
+            "from main before branch creation). Set "
+            "BMAD_GIT_WARN_LARGE_COMMITS_THRESHOLD=0 to disable this warning.",
+            len(modified_files),
+            threshold,
+            phase.value if phase else "unknown",
+            preview,
+            ", ..." if len(modified_files) > len(preview) else "",
+        )
+
     # CRITICAL: Check if any story files are marked for deletion
     # This prevents accidental permanent deletion of story artifacts
     deleted_story_files = check_for_deleted_story_files(project_path)
@@ -544,15 +625,26 @@ def auto_commit_phase(
         # Return False to halt the workflow - this is a critical error
         return False
 
-    # Stage all changes
-    if not stage_all_changes(project_path):
+    # Approach B: scope staging to the exclusion-filtered list from
+    # get_modified_files(). Previously ``git add -A`` unconditionally
+    # staged everything the working tree had modified — including files
+    # that the exclusion filter already decided should NOT be part of
+    # the auto-commit (e.g. generated artifacts in _bmad-output/). The
+    # filter was only applied to the LOG message. Now it's also applied
+    # to the actual staging. Honors ``BMAD_GIT_STAGE_ALL=1`` escape
+    # hatch for users who need the legacy behavior.
+    if not stage_all_changes(project_path, paths=modified_files):
         return False
 
     # Auto-fix pre-commit hook issues (ESLint + typecheck)
     _run_precommit_fix(project_path)
 
-    # Re-stage after lint fixes (eslint --fix may have modified files)
-    stage_all_changes(project_path)
+    # Re-stage after lint fixes. lint may have modified files in ways
+    # that also modify files outside our original filter — re-query the
+    # filtered list and stage THOSE. This keeps the staging scope
+    # consistent with the filter across both stage passes.
+    refreshed_files = get_modified_files(project_path)
+    stage_all_changes(project_path, paths=refreshed_files)
 
     # Generate commit message
     message = generate_commit_message(

--- a/src/bmad_assist/git/committer.py
+++ b/src/bmad_assist/git/committer.py
@@ -164,7 +164,7 @@ def check_for_deleted_story_files(project_path: Path) -> list[str]:
 
         # Check if it's a story file: docs/sprint-artifacts/{epic}-{story}-{slug}.md
         # or stories/{epic}-{story}-{slug}.md
-        story_pattern = re.compile(r"^(docs/sprint-artifacts/|stories/)?\d+-\d+-[\w-]+\.md$")
+        story_pattern = re.compile(r"^(docs/sprint-artifacts/|stories/)?\d+-\d+(?:[a-z](?:-[ivx]{2,})*)?-[\w-]+\.md$")
         if story_pattern.match(filename):
             deleted_files.append(filename)
 

--- a/src/bmad_assist/git/committer.py
+++ b/src/bmad_assist/git/committer.py
@@ -110,6 +110,58 @@ def _run_git(args: list[str], cwd: Path) -> tuple[int, str, str]:
         return 1, "", "Git not found in PATH"
 
 
+def _parse_porcelain_z(stdout: str) -> list[tuple[str, str]]:
+    """Parse ``git status --porcelain=v1 -z`` output.
+
+    We use ``-z`` because the default (text) porcelain format has a subtle
+    inconsistency: for staged-only modifications with an empty worktree
+    delta, some git versions emit ``M filename`` (2-char prefix: status
+    letter + separator space) instead of the documented ``XY filename``
+    (3-char prefix: 2-char status + separator space). That broke the
+    previous ``line[3:]`` slice, chopping the first char off filenames
+    (e.g. ``.bmad-assist/running.lock`` → ``bmad-assist/running.lock``),
+    which in turn made ``git add -- <path>`` fail with
+    ``pathspec did not match any files``.
+
+    The ``-z`` format is explicitly "for scripts": XY is **always** 2
+    chars, followed by a space, followed by the path, followed by NUL.
+    Renames (``R...``) and copies (``C...``) emit two records separated
+    by NUL: the new path first, then the old path.
+
+    Args:
+        stdout: Raw subprocess stdout (contains NUL separators).
+
+    Returns:
+        List of ``(status, path)`` tuples. ``status`` is the 2-char XY
+        code. For renames/copies, ``path`` is the NEW path (consistent
+        with legacy behavior of taking the post-rename name).
+
+    """
+    records = stdout.split("\x00")
+    results: list[tuple[str, str]] = []
+    i = 0
+    while i < len(records):
+        record = records[i]
+        if not record:
+            i += 1
+            continue
+        # Each record is "XY path" — XY is 2 chars, space separator.
+        if len(record) < 4:
+            # Malformed; skip defensively.
+            i += 1
+            continue
+        status = record[:2]
+        path = record[3:]
+        # Renames/copies: R? or C? in X consumes the next record as the
+        # OLD path. We keep the new path (already captured in ``path``).
+        if status and status[0] in ("R", "C") and i + 1 < len(records):
+            i += 2
+        else:
+            i += 1
+        results.append((status, path))
+    return results
+
+
 def get_modified_files(project_path: Path) -> list[str]:
     """Get list of modified files in the repository.
 
@@ -123,38 +175,37 @@ def get_modified_files(project_path: Path) -> list[str]:
         List of modified file paths relative to repo root.
 
     """
-    # Get both staged and unstaged changes
+    # Use -z for NUL-separated output with guaranteed 2-char XY status.
     exit_code, stdout, _ = _run_git(
-        ["status", "--porcelain", "-uall"],
+        ["status", "--porcelain=v1", "-uall", "-z"],
         project_path,
     )
 
     if exit_code != 0:
         return []
 
-    # Directories to exclude from auto-commit (generated artifacts)
+    # Directories to exclude from auto-commit (generated artifacts).
+    # ``.bmad-assist/runs/`` and ``.bmad-assist/running.lock`` are run-time
+    # state owned by bmad-assist itself — they change every run and would
+    # otherwise appear in every auto-commit as noise AND break ``git add``
+    # when the lock file is deleted between status + stage.
     exclude_prefixes = (
         "_bmad-output/",
         ".bmad-assist/prompts/",
         ".bmad-assist/cache/",
         ".bmad-assist/debug/",
+        ".bmad-assist/runs/",
     )
+    exclude_exact = (".bmad-assist/running.lock",)
 
-    files = []
-    for line in stdout.strip().split("\n"):
-        if line:
-            # porcelain format: XY filename
-            # Skip the status prefix (2 chars + space)
-            filename = line[3:].strip()
-            # Handle renamed files (old -> new)
-            if " -> " in filename:
-                filename = filename.split(" -> ")[1]
-
-            # Skip files in excluded directories
-            if any(filename.startswith(prefix) for prefix in exclude_prefixes):
-                continue
-
-            files.append(filename)
+    files: list[str] = []
+    for _status, filename in _parse_porcelain_z(stdout):
+        # Skip files in excluded directories
+        if any(filename.startswith(prefix) for prefix in exclude_prefixes):
+            continue
+        if filename in exclude_exact:
+            continue
+        files.append(filename)
 
     return files
 
@@ -172,8 +223,9 @@ def check_for_deleted_story_files(project_path: Path) -> list[str]:
         List of deleted story file paths. Empty if none found.
 
     """
+    # Use -z for deterministic parsing (see _parse_porcelain_z docstring).
     exit_code, stdout, _ = _run_git(
-        ["status", "--porcelain", "-uall"],
+        ["status", "--porcelain=v1", "-uall", "-z"],
         project_path,
     )
 
@@ -182,27 +234,18 @@ def check_for_deleted_story_files(project_path: Path) -> list[str]:
 
     import re
 
-    deleted_files = []
+    # docs/sprint-artifacts/{epic}-{story}-{slug}.md or stories/{epic}-{story}-{slug}.md
+    story_pattern = re.compile(
+        r"^(docs/sprint-artifacts/|stories/)?\d+-\d+"
+        r"(?:[a-z](?:-[ivx]{2,})*)?-[\w-]+\.md$"
+    )
 
-    for line in stdout.strip().split("\n"):
-        if not line:
-            continue
+    deleted_files: list[str] = []
 
-        # porcelain format: XY filename
-        # X = staged status, Y = unstaged status
-        # D in either position means deleted
-        status = line[:2]
-        filename = line[3:].strip()
-        if " -> " in filename:
-            filename = filename.split(" -> ")[1]
-
-        # Check if file is deleted (D in staged or unstaged status)
+    for status, filename in _parse_porcelain_z(stdout):
+        # Check if file is deleted (D in staged or unstaged status).
         if "D" not in status:
             continue
-
-        # Check if it's a story file: docs/sprint-artifacts/{epic}-{story}-{slug}.md
-        # or stories/{epic}-{story}-{slug}.md
-        story_pattern = re.compile(r"^(docs/sprint-artifacts/|stories/)?\d+-\d+(?:[a-z](?:-[ivx]{2,})*)?-[\w-]+\.md$")
         if story_pattern.match(filename):
             deleted_files.append(filename)
 

--- a/src/bmad_assist/git/diff.py
+++ b/src/bmad_assist/git/diff.py
@@ -6,13 +6,38 @@ Addresses the 92% false positive rate in code reviews by:
 - Validating diff quality before passing to reviewers
 """
 
+import fnmatch
 import logging
 import re
 import subprocess
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
+
+# Default regex patterns that classify a file as "garbage" (cache/metadata
+# /generated content). validate_diff_quality() composes this list with any
+# user-supplied extra patterns from config (GitConfig.garbage_extra_patterns)
+# and applies user-supplied exclusion paths (GitConfig.garbage_exclude_paths)
+# as a whitelist override.
+DEFAULT_GARBAGE_PATTERNS: tuple[str, ...] = (
+    r"^\.bmad-assist/",
+    r"^_bmad-output/",
+    r"\.cache$",
+    r"\.meta\.ya?ml$",
+    r"\.tpl\.xml$",
+    r"__pycache__",
+    r"node_modules/",
+    r"\.pyc$",
+    r"\.egg-info/",
+    r"\.pytest_cache/",
+    r"\.mypy_cache/",
+    r"\.ruff_cache/",
+    r"\.bmad/cache/",
+    r"package-lock\.json$",
+    r"\.lock$",
+)
 
 # Default timeout for git commands
 _GIT_TIMEOUT = 30
@@ -505,6 +530,8 @@ def extract_files_from_diff(diff_content: str) -> list[str]:
 def validate_diff_quality(
     diff_content: str,
     max_garbage_ratio: float = 0.3,
+    extra_garbage_patterns: Iterable[str] | None = None,
+    exclude_paths: Iterable[str] | None = None,
 ) -> DiffValidationResult:
     """Validate that diff contains mostly source files, not garbage.
 
@@ -513,6 +540,14 @@ def validate_diff_quality(
     Args:
         diff_content: Raw git diff output.
         max_garbage_ratio: Maximum allowed ratio of garbage files (default 30%).
+        extra_garbage_patterns: Additional regex patterns to classify as
+            garbage, appended to the built-in DEFAULT_GARBAGE_PATTERNS list.
+            Use this to flag generated files the defaults don't cover.
+        exclude_paths: Repo-relative paths or fnmatch-style glob patterns
+            that should NEVER be classified as garbage, even if they match
+            a regex above. Acts as a whitelist override. Use this for
+            tracked files like ".opencode/package-lock.json" that
+            legitimately appear in your diffs.
 
     Returns:
         DiffValidationResult with validation details.
@@ -530,29 +565,34 @@ def validate_diff_quality(
             issues=[],
         )
 
-    # Classify files
-    garbage_patterns = [
-        r"^\.bmad-assist/",
-        r"^_bmad-output/",
-        r"\.cache$",
-        r"\.meta\.ya?ml$",
-        r"\.tpl\.xml$",
-        r"__pycache__",
-        r"node_modules/",
-        r"\.pyc$",
-        r"\.egg-info/",
-        r"\.pytest_cache/",
-        r"\.mypy_cache/",
-        r"\.ruff_cache/",
-        r"\.bmad/cache/",
-        r"package-lock\.json$",
-        r"\.lock$",
-    ]
+    # Compose effective garbage patterns: defaults + user-supplied extras.
+    garbage_patterns: list[str] = list(DEFAULT_GARBAGE_PATTERNS)
+    if extra_garbage_patterns:
+        garbage_patterns.extend(extra_garbage_patterns)
+
+    # Pre-compile the exclude list once. Each entry is treated as a glob
+    # against the repo-relative path; entries without glob metacharacters
+    # match by exact equality (and by suffix, so users can list
+    # "package-lock.json" without worrying about parent dirs).
+    exclude_list = list(exclude_paths) if exclude_paths else []
+
+    def _is_excluded(path: str) -> bool:
+        for pattern in exclude_list:
+            if any(ch in pattern for ch in "*?["):
+                if fnmatch.fnmatch(path, pattern):
+                    return True
+            elif path == pattern or path.endswith("/" + pattern):
+                return True
+        return False
 
     garbage_files: list[str] = []
     source_files: list[str] = []
 
     for f in files:
+        if _is_excluded(f):
+            # Whitelisted by user config — always treat as source.
+            source_files.append(f)
+            continue
         is_garbage = any(re.search(p, f) for p in garbage_patterns)
         if is_garbage:
             garbage_files.append(f)
@@ -591,6 +631,8 @@ def get_validated_diff(
     base: str | None = None,
     max_garbage_ratio: float = 0.3,
     raise_on_invalid: bool = False,
+    extra_garbage_patterns: Iterable[str] | None = None,
+    exclude_paths: Iterable[str] | None = None,
 ) -> tuple[str, DiffValidationResult]:
     """Capture diff with filtering and validation.
 
@@ -601,6 +643,10 @@ def get_validated_diff(
         base: Base commit for diff (auto-detects if None).
         max_garbage_ratio: Maximum garbage file ratio before warning/error.
         raise_on_invalid: If True, raise DiffQualityError on validation failure.
+        extra_garbage_patterns: Additional regex patterns to classify as
+            garbage. See validate_diff_quality() for details.
+        exclude_paths: Paths/globs to whitelist from garbage detection.
+            See validate_diff_quality() for details.
 
     Returns:
         Tuple of (filtered diff content, validation result).
@@ -613,7 +659,12 @@ def get_validated_diff(
     diff_content = capture_filtered_diff(project_root, base=base)
 
     # Validate quality
-    validation = validate_diff_quality(diff_content, max_garbage_ratio)
+    validation = validate_diff_quality(
+        diff_content,
+        max_garbage_ratio=max_garbage_ratio,
+        extra_garbage_patterns=extra_garbage_patterns,
+        exclude_paths=exclude_paths,
+    )
 
     if not validation.is_valid:
         logger.warning(

--- a/src/bmad_assist/providers/claude.py
+++ b/src/bmad_assist/providers/claude.py
@@ -713,12 +713,23 @@ class ClaudeSubprocessProvider(BaseProvider):
                     duration_ms = int((time.perf_counter() - start_time) * 1000)
                     truncated = _truncate_prompt(prompt)
 
+                    # Log display_model (user-visible) when provided, fall back
+                    # to effective_model. When they differ (e.g. display_model=
+                    # "glm-5.1" via settings file, effective_model="opus"),
+                    # include both so logs aren't misleading.
+                    shown_model = display_model or effective_model
+                    model_label = (
+                        f"{shown_model} (sdk_model={effective_model})"
+                        if display_model and display_model != effective_model
+                        else shown_model
+                    )
+
                     partial_result = ProviderResult(
                         stdout="".join(response_text_parts),
                         stderr="".join(stderr_chunks),
                         exit_code=-1,
                         duration_ms=duration_ms,
-                        model=effective_model,
+                        model=shown_model,
                         command=tuple(command),
                     )
 
@@ -726,7 +737,7 @@ class ClaudeSubprocessProvider(BaseProvider):
                         "Provider timeout: provider=%s, model=%s, timeout=%ds, "
                         "duration_ms=%d, prompt=%s",
                         self.provider_name,
-                        effective_model,
+                        model_label,
                         effective_timeout,
                         duration_ms,
                         truncated,
@@ -741,7 +752,7 @@ class ClaudeSubprocessProvider(BaseProvider):
 
                     raise ProviderTimeoutError(
                         f"Claude CLI timeout after {effective_timeout}s "
-                        f"(model={effective_model}, prompt_chars={len(prompt)})",
+                        f"(model={model_label}, prompt_chars={len(prompt)})",
                         partial_result=partial_result,
                     )
 
@@ -800,11 +811,22 @@ class ClaudeSubprocessProvider(BaseProvider):
                 stderr_content[:STDERR_TRUNCATE_LENGTH] if stderr_content else "(empty)"
             )
 
+            # Log display_model (user-visible) with effective_model when they
+            # differ so operators aren't misled by e.g. "model=opus" when the
+            # user actually invoked via display_model="glm-5.1" pointing at
+            # a non-Anthropic endpoint via settings file.
+            shown_model = display_model or effective_model
+            model_label = (
+                f"{shown_model} (sdk_model={effective_model})"
+                if display_model and display_model != effective_model
+                else shown_model
+            )
+
             logger.error(
                 "Claude CLI failed: exit_code=%d, status=%s, model=%s, stderr=%s",
                 final_returncode,
                 exit_status.name,
-                effective_model,
+                model_label,
                 stderr_truncated,
             )
 

--- a/src/bmad_assist/providers/claude.py
+++ b/src/bmad_assist/providers/claude.py
@@ -740,7 +740,8 @@ class ClaudeSubprocessProvider(BaseProvider):
                         self._current_process = None
 
                     raise ProviderTimeoutError(
-                        f"Claude CLI timeout after {effective_timeout}s: {truncated}",
+                        f"Claude CLI timeout after {effective_timeout}s "
+                        f"(model={effective_model}, prompt_chars={len(prompt)})",
                         partial_result=partial_result,
                     )
 

--- a/src/bmad_assist/providers/claude_sdk.py
+++ b/src/bmad_assist/providers/claude_sdk.py
@@ -816,8 +816,8 @@ class ClaudeSDKProvider(BaseProvider):
             # Re-raise ProviderError (e.g., "No response received")
             raise
         except Exception as e:
-            # Check if this is a timeout-related error that should be retryable
             error_str = str(e).lower()
+            # Check if this is a timeout-related error that should be retryable
             if "timeout" in error_str or "control request timeout" in error_str:
                 duration_ms = int((time.perf_counter() - start_time) * 1000)
                 # Include captured stderr for diagnostics
@@ -836,6 +836,17 @@ class ClaudeSDKProvider(BaseProvider):
                     stderr_tail[:500] if stderr_tail else "(none captured)",
                 )
                 raise ProviderTimeoutError(f"SDK timeout: {e}") from e
+            # CLI crash (exit code 1) during message reading is transient —
+            # treat as retryable timeout so invoke_with_timeout_retry can retry
+            if "exit code" in error_str or "command failed" in error_str:
+                logger.warning(
+                    "SDK CLI crash (transient): model=%s, error=%s",
+                    effective_model,
+                    str(e)[:200],
+                )
+                raise ProviderTimeoutError(
+                    f"SDK CLI crash (retryable): {e}"
+                ) from e
             # Catch any unexpected exception and wrap in ProviderError
             # NO FALLBACK - error propagates immediately
             logger.error("Unexpected SDK error: %s", e)

--- a/src/bmad_assist/providers/claude_sdk.py
+++ b/src/bmad_assist/providers/claude_sdk.py
@@ -160,6 +160,72 @@ class ClaudeSDKProvider(BaseProvider):
         """
         return model in SUPPORTED_MODELS or model.startswith("claude-")
 
+    def _dump_stderr_debug_log(
+        self,
+        shown_model: str,
+        effective_model: str,
+        error: str,
+    ) -> None:
+        """Write captured SDK subprocess stderr + error to a per-run debug file.
+
+        The bundled claude-agent-sdk raises Exception("Command failed with exit
+        code 1: Check stderr output for details") with the literal string — the
+        actual stderr from the subprocess is only surfaced via the `stderr`
+        callback we passed to ClaudeAgentOptions, collected in
+        `self._last_stderr_lines`. This helper persists those lines (plus the
+        original error) to a timestamped file next to the run's prompts so
+        operators can diagnose the crash.
+
+        Writes on best-effort basis — failures to write are swallowed (we are
+        already in an error path and must not mask the original exception).
+
+        Args:
+            shown_model: Display model (user-visible name, e.g. "glm-5.1").
+            effective_model: Underlying Claude model the SDK was bound to.
+            error: str(exception) from the caught SDK failure.
+
+        """
+        try:
+            from bmad_assist.core.io import get_current_run_dir, get_timestamp
+
+            stderr_lines: list[str] = list(
+                getattr(self, "_last_stderr_lines", []) or []
+            )
+            # Nothing useful to dump and no error context worth saving
+            if not stderr_lines and not error:
+                return
+
+            run_dir = get_current_run_dir()
+            if run_dir is None:
+                # Outside a bmad-assist run (unit tests, ad-hoc invocation).
+                # Fall back to CLAUDE_SDK_DEBUG-controlled logging only — don't
+                # create orphan debug files in unknown locations.
+                logger.debug(
+                    "SDK crash stderr (no run dir): lines=%d, error=%s",
+                    len(stderr_lines),
+                    error[:200],
+                )
+                return
+
+            run_dir.mkdir(parents=True, exist_ok=True)
+            ts = get_timestamp()
+            debug_file = run_dir / f"sdk-stderr-{ts}.log"
+            header = (
+                f"# Claude SDK crash diagnostic\n"
+                f"# timestamp: {ts}\n"
+                f"# display_model: {shown_model}\n"
+                f"# effective_model: {effective_model}\n"
+                f"# stderr_lines_captured: {len(stderr_lines)}\n"
+                f"# error: {error[:500]}\n"
+                f"# ---\n"
+            )
+            body = "".join(stderr_lines) if stderr_lines else "(no stderr captured)\n"
+            debug_file.write_text(header + body, encoding="utf-8")
+            logger.info("SDK crash diagnostic written to %s", debug_file)
+        except Exception as dump_err:  # pragma: no cover - defensive
+            # Never let diagnostic dumping mask the original error
+            logger.debug("Failed to write SDK stderr debug log: %s", dump_err)
+
     def _resolve_settings(
         self,
         settings_file: Path | None,
@@ -394,6 +460,12 @@ class ClaudeSDKProvider(BaseProvider):
                     cli_path or "sdk-default",
                     len(self._last_stderr_lines),
                     stderr_tail[:300] if stderr_tail else "(none captured)",
+                )
+                # Persist full stderr to per-run debug file for post-mortem
+                self._dump_stderr_debug_log(
+                    shown_model=shown_model,
+                    effective_model=model,
+                    error=f"SDK initialization timeout ({init_timeout}s)",
                 )
                 # Remember failure timestamp — SDK will be retried after cooldown
                 global _sdk_init_failed_at
@@ -817,19 +889,34 @@ class ClaudeSDKProvider(BaseProvider):
             raise
         except Exception as e:
             error_str = str(e).lower()
+            # Log display model (user-visible) + underlying model when they differ,
+            # e.g. display_model="glm-5.1" but effective_model="opus" when pointed
+            # at a non-Anthropic endpoint via ~/.claude/glm.json settings file.
+            model_label = (
+                f"{shown_model} (sdk_model={effective_model})"
+                if shown_model != effective_model
+                else shown_model
+            )
+            # Capture stderr tail once for reuse across error branches.
+            stderr_tail = ""
+            if hasattr(self, "_last_stderr_lines") and self._last_stderr_lines:
+                stderr_tail = "; ".join(
+                    line.rstrip() for line in self._last_stderr_lines[-10:]
+                )
+            # Also dump full stderr to the per-run debug log so operators can
+            # diagnose "Command failed with exit code 1: (empty)" crashes.
+            self._dump_stderr_debug_log(
+                shown_model=shown_model,
+                effective_model=effective_model,
+                error=str(e),
+            )
             # Check if this is a timeout-related error that should be retryable
             if "timeout" in error_str or "control request timeout" in error_str:
                 duration_ms = int((time.perf_counter() - start_time) * 1000)
-                # Include captured stderr for diagnostics
-                stderr_tail = ""
-                if hasattr(self, "_last_stderr_lines") and self._last_stderr_lines:
-                    stderr_tail = "; ".join(
-                        line.rstrip() for line in self._last_stderr_lines[-10:]
-                    )
                 logger.warning(
                     "SDK initialization timeout: model=%s, duration_ms=%d, error=%s, "
                     "stderr_lines=%d, stderr_tail=%s",
-                    effective_model,
+                    model_label,
                     duration_ms,
                     str(e)[:100],
                     len(getattr(self, "_last_stderr_lines", [])),
@@ -840,16 +927,19 @@ class ClaudeSDKProvider(BaseProvider):
             # treat as retryable timeout so invoke_with_timeout_retry can retry
             if "exit code" in error_str or "command failed" in error_str:
                 logger.warning(
-                    "SDK CLI crash (transient): model=%s, error=%s",
-                    effective_model,
+                    "SDK CLI crash (transient): model=%s, error=%s, "
+                    "stderr_lines=%d, stderr_tail=%s",
+                    model_label,
                     str(e)[:200],
+                    len(getattr(self, "_last_stderr_lines", [])),
+                    stderr_tail[:500] if stderr_tail else "(none captured)",
                 )
                 raise ProviderTimeoutError(
                     f"SDK CLI crash (retryable): {e}"
                 ) from e
             # Catch any unexpected exception and wrap in ProviderError
             # NO FALLBACK - error propagates immediately
-            logger.error("Unexpected SDK error: %s", e)
+            logger.error("Unexpected SDK error (model=%s): %s", model_label, e)
             raise ProviderError(f"Unexpected SDK error: {e}") from e
 
         duration_ms = int((time.perf_counter() - start_time) * 1000)

--- a/src/bmad_assist/providers/gemini.py
+++ b/src/bmad_assist/providers/gemini.py
@@ -734,11 +734,29 @@ class GeminiProvider(BaseProvider):
                     command=tuple(command),
                 )
 
-                # Retry only on transient failures (empty stderr, general error status)
-                is_transient = not stderr_content.strip() and exit_status == ExitStatus.ERROR
+                # Retry on transient failures:
+                # 1. Empty stderr with general error status (generic transient)
+                # 2. HTTP 429 rate limit errors (explicit rate limiting)
+                stderr_lower = stderr_content.lower()
+                is_rate_limited = (
+                    "status 429" in stderr_lower
+                    or "rate limit" in stderr_lower
+                    or "resource exhausted" in stderr_lower
+                )
+                is_transient = (
+                    not stderr_content.strip() and exit_status == ExitStatus.ERROR
+                ) or is_rate_limited
 
                 if is_transient and attempt < MAX_RETRIES - 1:
                     last_error = error
+                    if is_rate_limited:
+                        # Extra backoff for rate limits (30s base, doubling)
+                        rate_delay = min(30.0 * (2 ** attempt), 120.0)
+                        logger.warning(
+                            "Gemini rate limited (429), backing off %.0fs before retry",
+                            rate_delay,
+                        )
+                        time.sleep(rate_delay)
                     continue  # Retry
 
                 # Not retryable or out of retries - raise the error

--- a/src/bmad_assist/providers/opencode.py
+++ b/src/bmad_assist/providers/opencode.py
@@ -60,6 +60,65 @@ logger = logging.getLogger(__name__)
 # Default timeout in seconds (5 minutes)
 DEFAULT_TIMEOUT: int = 300
 
+# Output-idle watchdog: if the subprocess produces NO bytes for this many
+# seconds, kill it early and raise ProviderTimeoutError. Complements the
+# hard wall-clock timeout — without this, a silently-stuck CLI (observed
+# with opencode/glm-5.1 producing no output for 30 minutes) wastes the
+# full ``timeout`` before recovery. Override with env var
+# ``BMAD_PROVIDER_IDLE_TIMEOUT`` (seconds); set to 0 to disable.
+_DEFAULT_IDLE_TIMEOUT_SECONDS: float = 300.0
+
+# How often to check the idle timestamp while waiting for the subprocess.
+_IDLE_POLL_INTERVAL_SECONDS: float = 5.0
+
+
+def _resolve_idle_timeout() -> float:
+    """Resolve the output-idle timeout from env var, falling back to default.
+
+    Returns 0.0 to disable the watchdog (in which case the main wait
+    loop still polls but never fires an idle timeout).
+    """
+    raw = os.environ.get("BMAD_PROVIDER_IDLE_TIMEOUT")
+    if raw is None:
+        return _DEFAULT_IDLE_TIMEOUT_SECONDS
+    try:
+        value = float(raw)
+    except ValueError:
+        logger.warning(
+            "Invalid BMAD_PROVIDER_IDLE_TIMEOUT=%r (expected float), using default %ss",
+            raw,
+            _DEFAULT_IDLE_TIMEOUT_SECONDS,
+        )
+        return _DEFAULT_IDLE_TIMEOUT_SECONDS
+    return max(0.0, value)
+
+
+class _IdleTracker:
+    """Thread-safe "last activity" timestamp for the output-idle watchdog.
+
+    Reader threads call :meth:`mark` on every byte/line received from the
+    subprocess. The main thread periodically checks :meth:`idle_for` and
+    kills the subprocess if it exceeds the configured idle timeout.
+
+    Python's GIL makes single float assignment atomic, so a lock isn't
+    strictly required — but using one keeps the semantics explicit and
+    future-proofs against GIL-free builds.
+    """
+
+    def __init__(self) -> None:
+        self._last_at: float = time.monotonic()
+        self._lock = threading.Lock()
+
+    def mark(self) -> None:
+        """Record that activity happened right now."""
+        with self._lock:
+            self._last_at = time.monotonic()
+
+    def idle_for(self) -> float:
+        """Return seconds since the last marked activity."""
+        with self._lock:
+            return time.monotonic() - self._last_at
+
 # Maximum prompt length in error messages before truncation
 PROMPT_TRUNCATE_LENGTH: int = 100
 
@@ -428,11 +487,18 @@ class OpenCodeProvider(BaseProvider):
                     text_parts: list[str],
                     json_logger: DebugJsonLogger,
                     color_idx: int | None,
+                    idle_tracker: _IdleTracker,
                 ) -> None:
                     """Process OpenCode stream-json output, extracting text and logging."""
                     nonlocal session_id
                     warned_tools: set[str] = set()  # Dedupe restricted tool warnings
                     for line in iter(stream.readline, ""):
+                        # Any byte from the CLI counts as activity — reset
+                        # the idle watchdog BEFORE processing so even empty
+                        # lines (which we skip below) still keep the
+                        # watchdog alive during a legitimate slow start.
+                        idle_tracker.mark()
+
                         stripped = line.strip()
                         if not stripped:
                             continue
@@ -534,9 +600,13 @@ class OpenCodeProvider(BaseProvider):
                     stream: Any,
                     chunks: list[str],
                     color_idx: int | None,
+                    idle_tracker: _IdleTracker,
                 ) -> None:
                     """Read stderr stream."""
                     for line in iter(stream.readline, ""):
+                        # stderr activity counts for the idle watchdog too
+                        # (e.g. auth errors, diagnostic logs).
+                        idle_tracker.mark()
                         chunks.append(line)
                         if should_print_progress():
                             stripped = line.rstrip()
@@ -553,6 +623,12 @@ class OpenCodeProvider(BaseProvider):
                     assert guard_kill_event is not None and guard_done_event is not None
                     guard_monitor = start_guard_monitor(process, guard_kill_event, guard_done_event)
 
+                # Output-idle watchdog: reader threads mark() on every byte
+                # received, and the main wait loop below polls idle_for()
+                # to kill a silently-stuck CLI early.
+                idle_tracker = _IdleTracker()
+                idle_timeout = _resolve_idle_timeout()
+
                 # Start reader threads
                 stdout_thread = threading.Thread(
                     target=process_json_stream,
@@ -561,11 +637,12 @@ class OpenCodeProvider(BaseProvider):
                         response_text_parts,
                         debug_json_logger,
                         color_index,
+                        idle_tracker,
                     ),
                 )
                 stderr_thread = threading.Thread(
                     target=read_stderr,
-                    args=(process.stderr, stderr_chunks, color_index),
+                    args=(process.stderr, stderr_chunks, color_index, idle_tracker),
                 )
                 stdout_thread.start()
                 stderr_thread.start()
@@ -579,10 +656,52 @@ class OpenCodeProvider(BaseProvider):
                     tag = format_tag("WAITING", color_index)
                     write_progress(f"{tag} Streaming response...")
 
-                # Wait for process with timeout
-                try:
-                    returncode = process.wait(timeout=effective_timeout)
-                except TimeoutExpired:
+                # Wait for process: two paths.
+                #
+                # 1. Short timeouts (timeout <= idle_timeout) OR watchdog
+                #    disabled: single-shot ``process.wait(timeout)``. The
+                #    idle watchdog can't physically fire in this regime
+                #    because the hard timeout wins first, so the polling
+                #    loop adds no value and would interfere with test
+                #    fixtures that mock ``wait`` to raise TimeoutExpired
+                #    immediately.
+                #
+                # 2. Long timeouts with idle watchdog enabled: poll every
+                #    _IDLE_POLL_INTERVAL_SECONDS. On each TimeoutExpired
+                #    from the inner wait:
+                #    - If total elapsed >= effective_timeout: hard.
+                #    - Else if idle_for() >= idle_timeout: early-kill
+                #      with reason="idle". Recovers minutes-faster from
+                #      silently-stuck CLIs (the observed failure mode).
+                timeout_reason: str | None = None
+                use_idle_polling = (
+                    idle_timeout > 0 and effective_timeout > idle_timeout
+                )
+                if not use_idle_polling:
+                    try:
+                        returncode = process.wait(timeout=effective_timeout)
+                    except TimeoutExpired:
+                        timeout_reason = "hard"
+                else:
+                    wait_start = time.perf_counter()
+                    while True:
+                        try:
+                            returncode = process.wait(
+                                timeout=_IDLE_POLL_INTERVAL_SECONDS
+                            )
+                            break
+                        except TimeoutExpired:
+                            elapsed = time.perf_counter() - wait_start
+                            if elapsed >= effective_timeout:
+                                timeout_reason = "hard"
+                                break
+                            if idle_tracker.idle_for() >= idle_timeout:
+                                timeout_reason = "idle"
+                                break
+                            # Still within budget; keep waiting.
+                            continue
+
+                if timeout_reason is not None:
                     process.kill()
                     # Join threads with timeout - should terminate quickly after kill
                     stdout_thread.join(timeout=2)
@@ -606,6 +725,25 @@ class OpenCodeProvider(BaseProvider):
                         model=effective_model,
                         command=tuple(command),
                     )
+
+                    if timeout_reason == "idle":
+                        idle_seconds = idle_tracker.idle_for()
+                        logger.warning(
+                            "Provider idle-timeout: provider=%s, model=%s, "
+                            "idle_for=%.1fs, limit=%.0fs, duration_ms=%d, prompt=%s",
+                            self.provider_name,
+                            effective_model,
+                            idle_seconds,
+                            idle_timeout,
+                            duration_ms,
+                            truncated,
+                        )
+                        raise ProviderTimeoutError(
+                            f"OpenCode CLI produced no output for "
+                            f"{idle_seconds:.0f}s (idle-timeout limit "
+                            f"{idle_timeout:.0f}s): {truncated}",
+                            partial_result=partial_result,
+                        ) from None
 
                     logger.warning(
                         "Provider timeout: provider=%s, model=%s, timeout=%ds, "

--- a/src/bmad_assist/providers/tool_guard.py
+++ b/src/bmad_assist/providers/tool_guard.py
@@ -5,8 +5,15 @@ and terminates sessions when runaway behavior is detected.
 
 Three detection mechanisms:
 1. Hard budget cap on total tool calls (default: 300)
-2. Per-file interaction cap — read+write+edit combined (default: 15)
+2. Per-file interaction cap — read+write+edit combined (default: 40,
+   elevated to 2x for files that were budget-trimmed out of the prompt
+   context — see ``elevated_file_paths`` below)
 3. Sliding-window per-minute rate cap (default: 90/min)
+
+The elevated per-file cap exists because budget-trimmed files don't appear
+in the prompt context — the model must read them via tool calls. A flat
+cap punishes legitimate use of tools to recover information the prompt
+trimmed away.
 
 Thread safety: check() and get_stats() are protected by an internal lock,
 safe for concurrent calls from stream-reader and main threads.
@@ -98,8 +105,16 @@ class ToolCallGuard:
 
     Args:
         max_total_calls: Hard cap on total tool calls (any type).
-        max_interactions_per_file: Max combined read+write+edit per file path.
+        max_interactions_per_file: Max combined read+write+edit per file path
+            for files that were already in the prompt context.
         max_calls_per_minute: Sliding-window rate cap.
+        elevated_file_paths: Optional set of normalized (realpath) file paths
+            that get an elevated per-file cap. Use for files that were
+            budget-trimmed out of the prompt context — the model must read
+            them via tool calls and a flat cap punishes that legitimate use.
+            Empty set means "no elevated paths".
+        max_interactions_per_file_elevated: Per-file cap for paths in
+            elevated_file_paths. None = auto: 2 * max_interactions_per_file.
         _clock: Injectable clock function for deterministic testing.
 
     """
@@ -107,8 +122,10 @@ class ToolCallGuard:
     def __init__(  # noqa: D107
         self,
         max_total_calls: int = 300,
-        max_interactions_per_file: int = 15,
+        max_interactions_per_file: int = 40,
         max_calls_per_minute: int = 90,
+        elevated_file_paths: set[str] | None = None,
+        max_interactions_per_file_elevated: int | None = None,
         _clock: Callable[[], float] | None = None,
     ) -> None:
         if max_total_calls < 1:
@@ -123,6 +140,23 @@ class ToolCallGuard:
         self.max_total_calls = max_total_calls
         self.max_interactions_per_file = max_interactions_per_file
         self.max_calls_per_minute = max_calls_per_minute
+        # Normalize elevated paths to realpath at construction time so the
+        # per-call lookup is just a set membership check (fast path).
+        self.elevated_file_paths: set[str] = {
+            os.path.realpath(p) for p in (elevated_file_paths or set())
+        }
+        # Resolve elevated cap (auto: 2x base, but never below base).
+        if max_interactions_per_file_elevated is not None:
+            if max_interactions_per_file_elevated < 1:
+                raise ValueError(
+                    "max_interactions_per_file_elevated must be >= 1, got "
+                    f"{max_interactions_per_file_elevated}"
+                )
+            self.max_interactions_per_file_elevated = max(
+                max_interactions_per_file_elevated, max_interactions_per_file
+            )
+        else:
+            self.max_interactions_per_file_elevated = max_interactions_per_file * 2
         self._clock = _clock or time.monotonic
         self._lock = threading.Lock()
 
@@ -135,12 +169,23 @@ class ToolCallGuard:
         self._terminated: bool = False
         self._terminated_reason: str | None = None
 
-        logger.info(
-            "ToolCallGuard active: budget=%d, file_cap=%d, rate=%d/min",
-            max_total_calls,
-            max_interactions_per_file,
-            max_calls_per_minute,
-        )
+        if self.elevated_file_paths:
+            logger.info(
+                "ToolCallGuard active: budget=%d, file_cap=%d, "
+                "elevated_file_cap=%d (for %d trimmed files), rate=%d/min",
+                max_total_calls,
+                max_interactions_per_file,
+                self.max_interactions_per_file_elevated,
+                len(self.elevated_file_paths),
+                max_calls_per_minute,
+            )
+        else:
+            logger.info(
+                "ToolCallGuard active: budget=%d, file_cap=%d, rate=%d/min",
+                max_total_calls,
+                max_interactions_per_file,
+                max_calls_per_minute,
+            )
 
     @property
     def is_triggered(self) -> bool:
@@ -184,14 +229,24 @@ class ToolCallGuard:
             return GuardVerdict(allowed=False, reason=reason)
 
         # --- Check per-file interaction cap ---
+        # Files that were budget-trimmed out of the prompt context get an
+        # elevated cap (the model has to read them via tools, so a flat
+        # base cap punishes legitimate use). Lookup uses realpath-normalized
+        # paths populated at construction time.
         file_path = self._extract_file_path(tool_name, tool_input)
         if file_path is not None:
             current_count = self._file_interactions.get(file_path, 0)
             would_be_file = current_count + 1
-            if would_be_file > self.max_interactions_per_file:
+            if file_path in self.elevated_file_paths:
+                effective_cap = self.max_interactions_per_file_elevated
+                cap_label = "elevated"
+            else:
+                effective_cap = self.max_interactions_per_file
+                cap_label = "base"
+            if would_be_file > effective_cap:
                 reason = (
                     f"file_interaction_cap:{file_path}"
-                    f"(would_be_{would_be_file}/{self.max_interactions_per_file})"
+                    f"(would_be_{would_be_file}/{effective_cap}:{cap_label})"
                 )
                 self._terminated = True
                 self._terminated_reason = reason

--- a/src/bmad_assist/sprint/classifier.py
+++ b/src/bmad_assist/sprint/classifier.py
@@ -61,7 +61,7 @@ _EPIC_META_PATTERN = re.compile(r"^epic-([a-z0-9][a-z0-9-]*)$")
 
 # Epic story: {epic_id}-{story_num}-{slug} where epic_id can be string or numeric
 # Requires at least: alphanumeric epic id, numeric story number, alphanumeric slug
-_EPIC_STORY_PATTERN = re.compile(r"^([a-z0-9][a-z0-9-]*)-(\d+)-([a-z0-9][a-z0-9-]*)$")
+_EPIC_STORY_PATTERN = re.compile(r"^([a-z0-9][a-z0-9-]*)-(\d+(?:[a-z](?:-[ivx]{2,})*)?)-([a-z0-9][a-z0-9-]*)$")
 
 
 def classify_entry(

--- a/src/bmad_assist/sprint/scanner.py
+++ b/src/bmad_assist/sprint/scanner.py
@@ -42,31 +42,31 @@ __all__ = [
 # ============================================================================
 
 # Story files: {epic}-{story}-{slug}.md
-# Examples: 20-1-entry-classification-system.md, testarch-1-config.md
+# Examples: 20-1-entry-classification-system.md, testarch-1-config.md, 10-3a-ii-command-registry.md
 STORY_FILENAME_PATTERN = re.compile(
-    r"^(?P<epic>[a-z0-9-]+)-(?P<story>\d+)-(?P<slug>[a-z0-9-]+)\.md$", re.IGNORECASE
+    r"^(?P<epic>[a-z0-9]+)-(?P<story>\d+(?:[a-z](?:-[ivx]{2,})*)?)-(?P<slug>[a-z0-9-]+)\.md$", re.IGNORECASE
 )
 
 # Code review synthesis: synthesis-{epic}-{story}[-timestamp].md
-# Examples: synthesis-20-4.md, synthesis-16-13-20260107_1112.md
+# Examples: synthesis-20-4.md, synthesis-16-13-20260107_1112.md, synthesis-10-3a-ii-20260410.md
 SYNTHESIS_PATTERN = re.compile(
-    r"^synthesis-(?P<epic>[a-z0-9-]+)-(?P<story>\d+)(?:-(?P<timestamp>[\dT_]+))?\.md$",
+    r"^synthesis-(?P<epic>[a-z0-9]+)-(?P<story>\d+(?:[a-z](?:-[ivx]{2,})*)?)(?:-(?P<timestamp>[\dT_]+))?\.md$",
     re.IGNORECASE,
 )
 
 # Code review: code-review-{epic}-{story}-{role_id}-{timestamp}.md
 # Examples: code-review-22-11-a-20260115T155525Z.md
 CODE_REVIEW_PATTERN = re.compile(
-    r"^code-review-(?P<epic>[a-z0-9-]+)-(?P<story>[a-z0-9]+)-(?P<role_id>[a-z])-"
+    r"^code-review-(?P<epic>[a-z0-9]+)-(?P<story>[a-z0-9]+)-(?P<role_id>[a-z])-"
     r"(?P<timestamp>[\dT_Z-]+)\.md$",
     re.IGNORECASE,
 )
 
 # Legacy code review: code-review-{epic}-{story}-{reviewer}-{timestamp}.md
 # Examples: code-review-1-4-master-20251209-233000.md, code-review-20-4-validator_g-20260107_1738.md
-# Note: story is digits only in legacy format; reviewer uses non-greedy to avoid capturing timestamp
+# Note: sub-story suffix is single letter + optional roman numeral (e.g., 3a, 3a-ii)
 LEGACY_REVIEW_PATTERN = re.compile(
-    r"^code-review-(?P<epic>[a-z0-9-]+)-(?P<story>\d+)-(?P<reviewer>[a-z0-9_-]+?)-"
+    r"^code-review-(?P<epic>[a-z0-9]+)-(?P<story>\d+(?:[a-z](?:-[ivx]{2,})*)?)-(?P<reviewer>[a-z0-9_-]+?)-"
     r"(?P<timestamp>\d[\dT_Z-]+)\.md$",
     re.IGNORECASE,
 )
@@ -74,14 +74,14 @@ LEGACY_REVIEW_PATTERN = re.compile(
 # New validation: validation-{epic}-{story}-{role_id}-{timestamp}.md
 # Examples: validation-22-11-a-20260115T155525Z.md
 NEW_VALIDATION_PATTERN = re.compile(
-    r"^validation-(?P<epic>[a-z0-9-]+)-(?P<story>[a-z0-9]+)-(?P<role_id>[a-z])-"
+    r"^validation-(?P<epic>[a-z0-9]+)-(?P<story>[a-z0-9]+)-(?P<role_id>[a-z])-"
     r"(?P<timestamp>[\dT_Z-]*)\.md$",
     re.IGNORECASE,
 )
 
 # Legacy validation: story-validation-{epic}-{story}-{reviewer}-{timestamp}.md
 LEGACY_VALIDATION_PATTERN = re.compile(
-    r"^story-validation-(?P<epic>[a-z0-9-]+)-(?P<story>\d+)-(?P<reviewer>[a-z0-9_]+)-"
+    r"^story-validation-(?P<epic>[a-z0-9]+)-(?P<story>\d+(?:[a-z](?:-[ivx]{2,})*)?)-(?P<reviewer>[a-z0-9_]+)-"
     r"(?P<timestamp>[\dT_-]+)\.md$",
     re.IGNORECASE,
 )
@@ -239,8 +239,9 @@ def _normalize_story_key(story_key: str) -> str:
         'testarch-1'
 
     """
-    # Match epic-story pattern at start
-    match = re.match(r"^([a-z0-9-]+?)-(\d+)", story_key, re.IGNORECASE)
+    # Match epic-story pattern at start (sub-story: single letter + optional roman numeral)
+    # The letter suffix and roman numerals are grouped: 3a, 3a-ii — never 3-ii alone
+    match = re.match(r"^([a-z0-9-]+?)-(\d+(?:[a-z](?:-[ivx]{2,})*)?)", story_key, re.IGNORECASE)
     if match:
         return f"{match.group(1).lower()}-{match.group(2)}"
     return story_key.lower()

--- a/src/bmad_assist/sprint/sync.py
+++ b/src/bmad_assist/sprint/sync.py
@@ -204,8 +204,8 @@ def _find_story_key(
     if not story_id:
         return None
 
-    # Convert dot to dash: "20.9" → "20-9"
-    prefix = story_id.replace(".", "-")
+    # Convert dot to dash: "20.9" → "20-9", "10.3a-ii" → "10-3a-ii"
+    prefix = story_id.replace(".", "-").lower()
 
     # Fast path: use prefix map if available
     if prefix_map is not None:
@@ -260,12 +260,15 @@ def _build_story_prefix_map(
         Dict mapping normalized prefix (e.g., "20-9") to full key (e.g., "20-9-sync").
 
     """
+    import re
+
     prefix_map: dict[str, str] = {}
     for key in entries:
-        # Extract prefix: "20-9-sync" → "20-9", "testarch-1-config" → "testarch-1"
-        parts = key.split("-", 2)
-        if len(parts) >= 2:
-            prefix = f"{parts[0]}-{parts[1]}"
+        # Extract prefix: "20-9-sync" → "20-9", "10-3a-ii-implement-..." → "10-3a-ii"
+        # Sub-story suffixes: single letter + optional roman numerals (ii, iii, iv)
+        m = re.match(r"^([a-z0-9]+-\d+(?:[a-z](?:-[ivx]{2,})*)?)", key, re.IGNORECASE)
+        if m:
+            prefix = m.group(1).lower()
             # First match wins (handles duplicates)
             if prefix not in prefix_map:
                 prefix_map[prefix] = key

--- a/src/bmad_assist/testarch/eligibility.py
+++ b/src/bmad_assist/testarch/eligibility.py
@@ -329,7 +329,7 @@ class ATDDEligibilityDetector:
             result = provider.invoke(
                 prompt,
                 model=config.providers.helper.model,
-                timeout=60,
+                timeout=config.providers.helper.timeout,
                 disable_tools=True,
                 no_cache=True,
             )

--- a/src/bmad_assist/testarch/handlers/base.py
+++ b/src/bmad_assist/testarch/handlers/base.py
@@ -24,12 +24,13 @@ from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from bmad_assist.core.config.loaders import get_phase_timeout
-from bmad_assist.core.exceptions import CompilerError
+from bmad_assist.core.config.loaders import get_phase_retries, get_phase_timeout
+from bmad_assist.core.exceptions import CompilerError, ProviderTimeoutError
 from bmad_assist.core.io import get_original_cwd
 from bmad_assist.core.loop.handlers.base import BaseHandler
 from bmad_assist.core.loop.types import PhaseResult
 from bmad_assist.core.paths import get_paths
+from bmad_assist.core.retry import invoke_with_timeout_retry
 from bmad_assist.core.state import State
 from bmad_assist.providers.base import ProviderResult
 
@@ -568,12 +569,90 @@ class TestarchBaseHandler(BaseHandler):
 
         return compile_workflow(workflow_name, context)
 
+    def _resolve_testarch_fallback(
+        self, primary_provider_name: str
+    ) -> "tuple[Callable[..., ProviderResult] | None, str | None, str | None]":
+        """Pick a sensible fallback callable for testarch provider invocations.
+
+        Testarch phases (ATDD, test_review, trace, NFR assess, etc.) run
+        heavy workflows that can hang — especially when pointed at remote
+        endpoints via opencode. Before this helper existed, a single
+        timeout killed the entire phase with no recovery path. This
+        resolves a fallback chain that mirrors the main loop handler:
+
+        1. ``claude`` primary → ``claude-subprocess`` fallback. Same
+           model family, different launch path, preserves the existing
+           SDK-init-timeout fallback behavior.
+        2. Any other primary → the configured ``providers.helper`` if
+           present AND its provider differs from the primary. Helper is
+           typically a fast model (haiku); ``invoke_with_timeout_retry``
+           auto-scales the fallback timeout to 1.5× the primary, so
+           ATDD's 1800s primary → 2700s helper timeout, plenty even
+           for a slower model.
+        3. Otherwise ``None`` — no fallback, retries alone (which still
+           helps for transient timeouts).
+
+        Args:
+            primary_provider_name: ``provider_name`` of the master
+                provider for this phase.
+
+        Returns:
+            Tuple of ``(fallback_invoke_fn, fallback_model, fallback_display_model)``.
+            All three are None when no fallback is configured.
+
+        """
+        # Case 1: claude → claude-subprocess (legacy behavior)
+        if primary_provider_name == "claude":
+            from bmad_assist.providers.claude import ClaudeSubprocessProvider
+
+            subprocess_provider = ClaudeSubprocessProvider()
+            # Subprocess uses the same model as the primary — caller
+            # already passes model via kwargs, so no override needed.
+            return subprocess_provider.invoke, None, None
+
+        # Case 2: helper fallback (if configured and different provider).
+        # We require helper.provider to be a non-empty string — this both
+        # guards against misconfigured Pydantic models AND keeps legacy
+        # testarch integration tests (which use bare MagicMock for the
+        # providers section) from picking up a phantom helper fallback.
+        helper = getattr(self.config.providers, "helper", None)
+        helper_provider_name = getattr(helper, "provider", None) if helper is not None else None
+        helper_model_value = getattr(helper, "model", None) if helper is not None else None
+        if (
+            helper is not None
+            and isinstance(helper_provider_name, str)
+            and helper_provider_name
+            and helper_provider_name != primary_provider_name
+            and isinstance(helper_model_value, str)
+            and helper_model_value
+        ):
+            from bmad_assist.providers import get_provider as _get_provider
+
+            helper_provider = _get_provider(helper_provider_name)
+            helper_display = getattr(helper, "display_model", None) or helper_model_value
+            logger.debug(
+                "Testarch fallback configured: primary=%s → helper=%s/%s",
+                primary_provider_name,
+                helper_provider_name,
+                helper_display,
+            )
+            return helper_provider.invoke, helper_model_value, helper_display
+
+        # Case 3: no fallback
+        return None, None, None
+
     def _invoke_workflow(
         self,
         compiled: CompiledWorkflow,
         timeout: int | None = None,
     ) -> ProviderResult | PhaseResult:
         """Invoke master provider with compiled workflow.
+
+        Uses ``invoke_with_timeout_retry`` to honor the configured
+        per-phase retry count and fall back to a secondary provider on
+        timeout exhaustion. Previously called ``provider.invoke()``
+        directly, which meant a single 30-minute hang on e.g. opencode
+        / glm-5.1 killed the entire phase with no recovery path.
 
         Args:
             compiled: Compiled workflow.
@@ -588,22 +667,88 @@ class TestarchBaseHandler(BaseHandler):
         from bmad_assist.providers import get_provider
 
         try:
-            provider_name = self.config.providers.master.provider
+            master = self.config.providers.master
+            provider_name = master.provider
             provider = get_provider(provider_name)
-            model = self.config.providers.master.model
+            model = master.model
+            display_model = getattr(master, "display_model", None) or model
 
             # Default timeout from config if not provided
             timeout_val = timeout or getattr(self.config, "timeout", 120)
 
-            return provider.invoke(
-                prompt=compiled.context,
-                model=model,
-                timeout=timeout_val,
-                cwd=self.project_path,
+            # Resolve retry count for this phase (matches main-loop behavior).
+            # None = no retry (legacy default); 0 = infinite; N = N retries.
+            timeout_retries = get_phase_retries(self.config, self.phase_name)
+
+            # Resolve fallback chain (claude-subprocess or helper provider).
+            fallback_invoke_fn, fallback_model, fallback_display_model = (
+                self._resolve_testarch_fallback(provider_name)
+            )
+
+            # Build invoke kwargs. When the fallback is the helper
+            # provider (different from primary), its model and
+            # display_model differ too — invoke_with_timeout_retry
+            # passes one **kwargs dict to both primary and fallback,
+            # so we bake the fallback model into a fb_kwargs override
+            # here via a lambda wrapper rather than letting the primary
+            # model leak into the fallback call.
+            primary_kwargs: dict[str, Any] = {
+                "prompt": compiled.context,
+                "model": model,
+                "display_model": display_model,
+                "timeout": timeout_val,
+                "cwd": self.project_path,
+            }
+
+            if (
+                fallback_invoke_fn is not None
+                and fallback_model is not None
+                and fallback_model != model
+            ):
+                # Helper fallback with its own model — wrap to rewrite
+                # model + display_model when called.
+                _fb = fallback_invoke_fn
+                _fb_model = fallback_model
+                _fb_display = fallback_display_model
+
+                def _fallback_with_helper_model(**kwargs: Any) -> ProviderResult:
+                    overridden = {
+                        **kwargs,
+                        "model": _fb_model,
+                        "display_model": _fb_display,
+                    }
+                    logger.info(
+                        "Testarch fallback: invoking helper provider "
+                        "with model=%s (primary model=%s timed out)",
+                        _fb_display,
+                        model,
+                    )
+                    return _fb(**overridden)
+
+                fallback_invoke_fn = _fallback_with_helper_model
+
+            return invoke_with_timeout_retry(
+                provider.invoke,
+                timeout_retries=timeout_retries,
+                phase_name=self.phase_name,
+                fallback_invoke_fn=fallback_invoke_fn,
+                fallback_timeout_retries=timeout_retries,
+                **primary_kwargs,
             )
         except CompilerError as e:
             logger.error("Compiler error: %s", e)
             return PhaseResult.fail(f"Compiler error: {e}")
+        except ProviderTimeoutError as e:
+            # All retries and fallback exhausted — bubble up as a
+            # failure so the loop can record the error and move on.
+            logger.error(
+                "Testarch provider timeout in %s (retries + fallback exhausted): %s",
+                self.phase_name,
+                str(e)[:200],
+            )
+            return PhaseResult.fail(
+                f"Provider timeout in {self.phase_name}: {str(e)[:200]}"
+            )
         except Exception as e:
             logger.error("Provider invocation failed: %s", e)
             return PhaseResult.fail(f"Provider invocation failed: {e}")

--- a/src/bmad_assist/testarch/handlers/base.py
+++ b/src/bmad_assist/testarch/handlers/base.py
@@ -571,7 +571,7 @@ class TestarchBaseHandler(BaseHandler):
 
     def _resolve_testarch_fallback(
         self, primary_provider_name: str
-    ) -> "tuple[Callable[..., ProviderResult] | None, str | None, str | None]":
+    ) -> tuple[Callable[..., ProviderResult] | None, str | None, str | None]:
         """Pick a sensible fallback callable for testarch provider invocations.
 
         Testarch phases (ATDD, test_review, trace, NFR assess, etc.) run

--- a/src/bmad_assist/validation/benchmarking_integration.py
+++ b/src/bmad_assist/validation/benchmarking_integration.py
@@ -131,7 +131,7 @@ def _parse_role_id(
 
 def _create_collector_context(
     story_epic: EpicId,
-    story_num: int,
+    story_num: int | str,
     timestamp: datetime,
 ) -> CollectorContext:
     """Create CollectorContext for deterministic metrics.

--- a/src/bmad_assist/validation/evidence_score.py
+++ b/src/bmad_assist/validation/evidence_score.py
@@ -515,9 +515,13 @@ def parse_evidence_findings(
 
     # If no findings and no clean passes and no score, return None
     if not findings and clean_passes == 0 and parsed_score is None:
+        # Log snippet of content for format diagnosis
+        snippet = content[:300].replace("\n", " ").strip() if content else "(empty)"
         logger.warning(
-            "Failed to parse Evidence Score from %s: no findings, clean passes, or score found",
+            "Failed to parse Evidence Score from %s: no findings, clean passes, "
+            "or score found. Content preview: %.300s",
             validator_id,
+            snippet,
         )
         return None
 

--- a/src/bmad_assist/validation/evidence_score.py
+++ b/src/bmad_assist/validation/evidence_score.py
@@ -369,11 +369,53 @@ _CLEAN_PASS_TEXT_PATTERN = re.compile(
 )
 
 # Pattern for total Evidence Score
-# | **Evidence Score** | **3.5** | or Evidence Score: 3.5
+# Matches:
+#   Evidence Score: 3.5
+#   **Evidence Score:** 3.5
+#   | **Evidence Score** | **3.5** |
+# The `\*{0,2}` parts allow optional bold wrapping in any of the common
+# positions reviewers actually emit. Parser uses .search() and picks the
+# first non-None group.
+#
+# The trailing `(?![\d/%])` negative lookahead is critical: it prevents
+# the regex from greedily backtracking and matching a partial digit out
+# of fraction notation like ``Evidence Score: 43/55`` (where the regex
+# would otherwise match `4` and produce parsed_score=4.0). Fractions are
+# handled separately by _SCORE_FRACTION_PATTERN below.
 _EVIDENCE_SCORE_PATTERN = re.compile(
-    r"(?:Evidence Score:?\s*\*?\*?(-?\d+(?:\.\d+)?)\*?\*?"
-    r"|\|\s*\*?\*?Evidence Score\*?\*?\s*\|\s*\*?\*?(-?\d+(?:\.\d+)?)\*?\*?\s*\|)",
+    r"(?:"
+    # Inline form: optionally wrapped in **, with optional ** after the
+    # colon (e.g. **Evidence Score:** 3.5).
+    r"\*{0,2}Evidence Score\*{0,2}\s*:?\s*\*{0,2}\s*(-?\d+(?:\.\d+)?)\*{0,2}(?![\d/%])"
+    r"|"
+    # Table form: | **Evidence Score** | **3.5** |
+    r"\|\s*\*{0,2}Evidence Score\*{0,2}\s*\|\s*\*{0,2}(-?\d+(?:\.\d+)?)\*{0,2}\s*\|"
+    r")",
     re.IGNORECASE,
+)
+
+# Pattern for score-card "Total" or "Evidence Score" lines that report a
+# fraction (achieved/maximum) rather than a single Evidence Score number.
+# Real-world reports the parser was failing on:
+#
+#   **Total: 58/100**
+#   | **Total** | **43/55** | **55** | |
+#   **Evidence Score:** 43/55 → **78%**
+#
+# Capture groups: 1=achieved, 2=maximum.
+_SCORE_FRACTION_PATTERN = re.compile(
+    r"\*{0,2}(?:Total|Evidence Score)\*{0,2}\s*[:|]?\s*\*{0,2}\s*"
+    r"(\d+(?:\.\d+)?)\s*/\s*(\d+(?:\.\d+)?)\s*\*{0,2}",
+    re.IGNORECASE,
+)
+
+# Sanity guard for _SCORE_FRACTION_PATTERN: only treat a fraction as an
+# Evidence Score when there's a recognizable Evidence Score / Score Card
+# heading in the report. Avoids misinterpreting unrelated "Total: X/Y"
+# lines (e.g. test pass rates) as the report's verdict.
+_EVIDENCE_SCORE_HEADING_PATTERN = re.compile(
+    r"^#{2,5}\s*Evidence\s+Score(?:\s+Card)?\s*$",
+    re.IGNORECASE | re.MULTILINE,
 )
 
 
@@ -512,6 +554,49 @@ def parse_evidence_findings(
     score_match = _EVIDENCE_SCORE_PATTERN.search(content)
     if score_match:
         parsed_score = float(score_match.group(1) or score_match.group(2))
+
+    # Score-card fraction fallback: when the report uses a "Total: N/M" or
+    # "Evidence Score: N/M" line under an "## Evidence Score [Card]" heading,
+    # convert the missed-percentage to a bmad Evidence Score on the 0..10
+    # scale so the existing verdict thresholds (>=6 REJECT, 4-6 REWORK, <=3
+    # PASS) line up with what the reviewer actually said.
+    #
+    # Examples:
+    #   58/100 → 42% missed → score ≈ 4.2 → MAJOR_REWORK
+    #   43/55  → ~22% missed → score ≈ 2.2 → PASS
+    #
+    # Only fires when no other strategy yielded findings or a parsed score,
+    # AND when the report has a recognizable Evidence Score heading (see
+    # _EVIDENCE_SCORE_HEADING_PATTERN) — protects against false positives.
+    if (
+        not findings
+        and clean_passes == 0
+        and parsed_score is None
+        and _EVIDENCE_SCORE_HEADING_PATTERN.search(content)
+    ):
+        frac_match = _SCORE_FRACTION_PATTERN.search(content)
+        if frac_match:
+            try:
+                achieved = float(frac_match.group(1))
+                maximum = float(frac_match.group(2))
+                if maximum > 0 and achieved <= maximum:
+                    missed_ratio = (maximum - achieved) / maximum
+                    parsed_score = round(missed_ratio * 10.0, 1)
+                    parse_warnings.append(
+                        f"Evidence Score derived from score-card fraction "
+                        f"{achieved:g}/{maximum:g} → {parsed_score}"
+                    )
+                    logger.info(
+                        "Evidence Score from %s score-card: %g/%g → %.1f",
+                        validator_id,
+                        achieved,
+                        maximum,
+                        parsed_score,
+                    )
+            except (ValueError, ZeroDivisionError) as e:
+                parse_warnings.append(
+                    f"Failed to parse score-card fraction: {e}"
+                )
 
     # If no findings and no clean passes and no score, return None
     if not findings and clean_passes == 0 and parsed_score is None:

--- a/src/bmad_assist/validation/evidence_score.py
+++ b/src/bmad_assist/validation/evidence_score.py
@@ -359,6 +359,19 @@ _SECTION_HEADER_PATTERN = re.compile(
     re.IGNORECASE | re.MULTILINE,
 )
 
+# Numbered finding heading pattern:
+#   ### CRITICAL-1: Missing active_instance_index() in CoreConnection Trait
+#   ### IMPORTANT-3: ConnectionManager file placement
+#   ### MINOR-2: View mode label hardcoded
+# Adversarial validation reports often group findings under a section
+# heading like "## 3. Critical Issues" but list each finding as its own
+# numbered subheading rather than bullet points. Each match is one
+# finding; the description is everything after the colon.
+_NUMBERED_FINDING_HEADING_PATTERN = re.compile(
+    rf"^#{{2,5}}\s+({_ALL_SEVERITY_LABELS})-\d+\s*:?\s*(.+?)\s*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+
 # Pattern for CLEAN PASS count
 # | 🟢 CLEAN PASS | 5 |
 _CLEAN_PASS_TABLE_PATTERN = re.compile(r"\|\s*🟢\s*CLEAN PASS\s*\|\s*(\d+)\s*\|", re.IGNORECASE)
@@ -413,8 +426,11 @@ _SCORE_FRACTION_PATTERN = re.compile(
 # Evidence Score when there's a recognizable Evidence Score / Score Card
 # heading in the report. Avoids misinterpreting unrelated "Total: X/Y"
 # lines (e.g. test pass rates) as the report's verdict.
+#
+# Accepts an optional numeric prefix like "11." so reports that use
+# numbered sections (e.g. "## 11. Evidence Score") still match.
 _EVIDENCE_SCORE_HEADING_PATTERN = re.compile(
-    r"^#{2,5}\s*Evidence\s+Score(?:\s+Card)?\s*$",
+    r"^#{2,5}\s*(?:\d+(?:\.\d+)*\.?\s*)?Evidence\s+Score(?:\s+Card)?\s*$",
     re.IGNORECASE | re.MULTILINE,
 )
 
@@ -511,6 +527,34 @@ def parse_evidence_findings(
                 )
             except (ValueError, KeyError) as e:
                 parse_warnings.append(f"Failed to parse bullet finding: {e}")
+
+    # Try numbered finding headings (### CRITICAL-1: description).
+    # Run BEFORE the section-header fallback because numbered headings are
+    # more specific — the broader section-header pattern would otherwise
+    # match the section title alone (e.g. "## 3. Critical Issues") and
+    # then look for bullets that don't exist, producing zero findings.
+    if not findings:
+        numbered_matches = _NUMBERED_FINDING_HEADING_PATTERN.findall(content)
+        for severity_str, description in numbered_matches:
+            try:
+                severity = _resolve_severity(severity_str)
+                # Use the canonical bmad weight for this severity
+                # (CRITICAL=3, IMPORTANT=1, MINOR=0.3) — validators using
+                # this format don't put a per-finding score on the heading.
+                score = SEVERITY_SCORES[severity.value]
+                findings.append(
+                    EvidenceFinding(
+                        severity=severity,
+                        score=score,
+                        description=description.strip(),
+                        source="",
+                        validator_id=validator_id,
+                    )
+                )
+            except (ValueError, KeyError) as e:
+                parse_warnings.append(
+                    f"Failed to parse numbered finding heading: {e}"
+                )
 
     # Try section-header fallback if no findings yet
     if not findings:

--- a/src/bmad_assist/validation/orchestrator.py
+++ b/src/bmad_assist/validation/orchestrator.py
@@ -48,6 +48,7 @@ from bmad_assist.benchmarking import (
 from bmad_assist.compiler import compile_workflow
 from bmad_assist.compiler.types import CompilerContext
 from bmad_assist.core.config import Config, get_phase_retries, get_phase_timeout
+from bmad_assist.core.config.models.features import ToolGuardConfig
 from bmad_assist.core.config.loaders import parse_parallel_delay
 from bmad_assist.core.config.models.providers import (
     MultiProviderConfig,
@@ -293,6 +294,7 @@ async def _invoke_validator(
     display_model: str | None = None,
     thinking: bool | None = None,
     reasoning_effort: str | None = None,
+    tool_guard_config: ToolGuardConfig | None = None,
 ) -> tuple[str, ValidationOutput | None, DeterministicMetrics | None, str | None]:
     """Invoke a single validator using asyncio.to_thread.
 
@@ -335,7 +337,14 @@ async def _invoke_validator(
         # Per-provider guard for multi-LLM independence
         from bmad_assist.providers.tool_guard import ToolCallGuard
 
-        guard = ToolCallGuard()
+        if tool_guard_config is not None:
+            guard = ToolCallGuard(
+                max_total_calls=tool_guard_config.max_total_calls,
+                max_interactions_per_file=tool_guard_config.max_interactions_per_file,
+                max_calls_per_minute=tool_guard_config.max_calls_per_minute,
+            )
+        else:
+            guard = ToolCallGuard()
 
         # Setup fallback for claude-sdk provider (SDK init timeout -> subprocess)
         fallback_invoke_fn = None
@@ -616,6 +625,7 @@ async def run_validation_phase(
             display_model=multi_config.display_model,
             thinking=multi_config.thinking,
             reasoning_effort=multi_config.reasoning_effort,
+            tool_guard_config=config.tool_guard,
         )
         task = asyncio.create_task(delayed_invoke(delay, coro))
         tasks.append(task)
@@ -646,6 +656,7 @@ async def run_validation_phase(
             color_index=master_color_index,
             cwd=project_path,
             display_model=config.providers.master.display_model,
+            tool_guard_config=config.tool_guard,
         )
         master_task = asyncio.create_task(delayed_invoke(master_delay, master_coro))
         tasks.append(master_task)

--- a/src/bmad_assist/validation/orchestrator.py
+++ b/src/bmad_assist/validation/orchestrator.py
@@ -48,8 +48,8 @@ from bmad_assist.benchmarking import (
 from bmad_assist.compiler import compile_workflow
 from bmad_assist.compiler.types import CompilerContext
 from bmad_assist.core.config import Config, get_phase_retries, get_phase_timeout
-from bmad_assist.core.config.models.features import ToolGuardConfig
 from bmad_assist.core.config.loaders import parse_parallel_delay
+from bmad_assist.core.config.models.features import ToolGuardConfig
 from bmad_assist.core.config.models.providers import (
     MultiProviderConfig,
     get_phase_provider_config,

--- a/src/bmad_assist/validation/orchestrator.py
+++ b/src/bmad_assist/validation/orchestrator.py
@@ -54,7 +54,7 @@ from bmad_assist.core.config.models.providers import (
     MultiProviderConfig,
     get_phase_provider_config,
 )
-from bmad_assist.core.exceptions import BmadAssistError
+from bmad_assist.core.exceptions import BmadAssistError, ProviderError
 from bmad_assist.core.io import get_original_cwd, save_prompt
 from bmad_assist.core.retry import invoke_with_timeout_retry
 
@@ -477,7 +477,21 @@ async def _invoke_validator(
         logger.warning(error_msg)
         return provider_id, None, None, error_msg
 
+    except ProviderError as e:
+        # Expected operational failure from the provider layer (auth
+        # error, rate limit, non-zero exit, timeout, etc.). The error
+        # message already carries the diagnostic from stderr, and the
+        # Python stack trace through asyncio/retry/provider adds no
+        # information the operator can act on. Log cleanly without
+        # exc_info so multi-LLM parallel runs don't drown the log in
+        # duplicate tracebacks on a provider-wide outage.
+        error_msg = f"Validator {provider_id} failed: {e}"
+        logger.warning(error_msg)
+        return provider_id, None, None, error_msg
+
     except Exception as e:
+        # Unexpected exception (TypeError, AttributeError, etc.) —
+        # likely indicates a bmad-assist bug. Keep the full traceback.
         error_msg = f"Validator {provider_id} failed: {e}"
         logger.warning(error_msg, exc_info=True)
         return provider_id, None, None, error_msg

--- a/src/bmad_assist/validation/orchestrator.py
+++ b/src/bmad_assist/validation/orchestrator.py
@@ -339,7 +339,12 @@ async def _invoke_validator(
 
         if tool_guard_config is not None:
             guard = ToolCallGuard(
-                max_total_calls=tool_guard_config.max_total_calls,
+                # Honor per-phase max_total_calls override (e.g. raised cap
+                # for heavy phases configured via
+                # tool_guard.max_total_calls_per_phase in bmad-assist.yaml).
+                max_total_calls=tool_guard_config.get_max_total_calls(
+                    "validate_story"
+                ),
                 max_interactions_per_file=tool_guard_config.max_interactions_per_file,
                 max_calls_per_minute=tool_guard_config.max_calls_per_minute,
             )

--- a/src/bmad_assist/validation/orchestrator.py
+++ b/src/bmad_assist/validation/orchestrator.py
@@ -574,6 +574,20 @@ async def run_validation_phase(
     # Step 2: Build list of validators (multi + master)
     timeout = get_phase_timeout(config, "validate_story")
     timeout_retries = get_phase_retries(config, "validate_story")
+
+    # Scale timeout proportionally to prompt size — large prompts
+    # need more time for LLM processing and tool interactions
+    reference_prompt_chars = 100_000
+    if len(prompt) > reference_prompt_chars:
+        base_timeout = timeout
+        timeout = int(timeout * (len(prompt) / reference_prompt_chars))
+        logger.debug(
+            "Scaled validation timeout: base=%d, prompt_chars=%d, effective=%d",
+            base_timeout,
+            len(prompt),
+            timeout,
+        )
+
     # AC7: Check if benchmarking is enabled
     benchmarking_enabled = should_collect_benchmarking(config)
     if benchmarking_enabled:

--- a/src/bmad_assist/validation/reports.py
+++ b/src/bmad_assist/validation/reports.py
@@ -693,7 +693,7 @@ def save_synthesis_report(
     session_id: str,
     validators_used: list[str],
     epic: EpicId,
-    story: int,
+    story: int | str,
     duration_ms: int,
     validations_dir: Path,
     run_timestamp: datetime | None = None,

--- a/src/bmad_assist/validation/reports.py
+++ b/src/bmad_assist/validation/reports.py
@@ -90,6 +90,7 @@ def extract_validation_report(raw_output: str) -> str:
 def extract_synthesis_report(
     raw_output: str,
     synthesis_type: str = "validation",
+    termination_reason: str | None = None,
 ) -> str:
     r"""Extract synthesis report content from LLM output.
 
@@ -127,6 +128,7 @@ def extract_synthesis_report(
         raw_output,
         markers,
         stop_at_markers=[_METRICS_START_MARKER],
+        termination_reason=termination_reason,
     )
 
 

--- a/tests/antipatterns/test_extractor_debug_logging.py
+++ b/tests/antipatterns/test_extractor_debug_logging.py
@@ -1,0 +1,69 @@
+"""Tests for antipattern extractor debug logging (Fix #9)."""
+
+import logging
+from unittest.mock import MagicMock
+
+from bmad_assist.antipatterns.extractor import extract_antipatterns
+
+
+def _make_config(enabled: bool = True) -> MagicMock:
+    """Create a mock config with antipatterns settings."""
+    config = MagicMock()
+    config.antipatterns.enabled = enabled
+    return config
+
+
+class TestZeroAntipatternDebugLogging:
+    """Test debug logging when Issues Verified section found but 0 items."""
+
+    def test_section_found_zero_items_logs_debug(self, caplog) -> None:
+        """Section present but no parseable items logs debug message."""
+        content = """## Summary
+Some summary.
+
+## Issues Verified (by severity)
+
+No issues found in this review.
+
+## Changes Applied
+Some changes.
+"""
+        with caplog.at_level(logging.DEBUG):
+            result = extract_antipatterns(content, 10, "10-3", _make_config())
+        assert len(result) == 0
+        assert "0 items extracted" in caplog.text
+        assert "10-3" in caplog.text
+
+    def test_no_section_logs_different_debug(self, caplog) -> None:
+        """Content without Issues Verified section logs 'not found'."""
+        content = "## Summary\nSome content without issues section."
+        with caplog.at_level(logging.DEBUG):
+            result = extract_antipatterns(content, 10, "10-4", _make_config())
+        assert len(result) == 0
+        assert "No 'Issues Verified' section found" in caplog.text
+
+    def test_section_with_items_no_zero_warning(self, caplog) -> None:
+        """Section with valid items does NOT log '0 items extracted'."""
+        content = """## Issues Verified (by severity)
+
+### Critical
+- **Issue**: Missing auth check | **Fix**: Added middleware
+
+## Changes Applied
+"""
+        with caplog.at_level(logging.DEBUG):
+            result = extract_antipatterns(content, 10, "10-5", _make_config())
+        assert len(result) > 0
+        assert "0 items extracted" not in caplog.text
+
+    def test_debug_log_includes_section_length(self, caplog) -> None:
+        """Debug message includes section character count."""
+        content = """## Issues Verified (by severity)
+
+Nothing actionable here.
+
+## Next Section
+"""
+        with caplog.at_level(logging.DEBUG):
+            extract_antipatterns(content, 10, "10-6", _make_config())
+        assert "section length:" in caplog.text

--- a/tests/bmad/test_state_reader.py
+++ b/tests/bmad/test_state_reader.py
@@ -25,6 +25,7 @@ from pathlib import Path
 
 import pytest
 
+from bmad_assist.bmad.parser import EpicDocument, EpicStory
 from bmad_assist.bmad.state_reader import (
     ProjectState,
     _apply_default_status,
@@ -37,7 +38,6 @@ from bmad_assist.bmad.state_reader import (
     _story_sort_key,
     read_project_state,
 )
-from bmad_assist.bmad.parser import EpicDocument, EpicStory
 
 
 class TestDiscoverEpicFiles:
@@ -1080,33 +1080,43 @@ class TestHelperFunctions:
 
     def test_story_sort_key(self) -> None:
         """Test _story_sort_key generates correct sort keys."""
-        # Numeric epic ID: (0, epic_num, story_num)
         story = EpicStory(number="2.3", title="Test")
         key = _story_sort_key(story)
-        assert key == (0, 2, 3)
+        assert key == (0, 2, (3, "", []))
 
     def test_story_sort_key_string_epic(self) -> None:
         """Test _story_sort_key handles string epic IDs."""
-        # String epic ID: (1, epic_id, story_num)
         story = EpicStory(number="testarch.1", title="Test")
         key = _story_sort_key(story)
-        assert key == (1, "testarch", 1)
+        assert key == (1, "testarch", (1, "", []))
 
     def test_story_sort_key_invalid_format(self, caplog: pytest.LogCaptureFixture) -> None:
         """Test _story_sort_key handles invalid format gracefully."""
         story = EpicStory(number="invalid", title="Test")
         with caplog.at_level(logging.WARNING):
             key = _story_sort_key(story)
-        assert key == (0, 0, 0)
+        assert key == (0, 0, (0, "", []))
         assert "Invalid story number format" in caplog.text
 
-    def test_story_sort_key_non_numeric(self, caplog: pytest.LogCaptureFixture) -> None:
-        """Test _story_sort_key handles non-numeric story numbers gracefully."""
-        story = EpicStory(number="2.a", title="Test")
-        with caplog.at_level(logging.WARNING):
-            key = _story_sort_key(story)
-        assert key == (0, 0, 0)
-        assert "Non-numeric story number" in caplog.text
+    def test_story_sort_key_substory(self) -> None:
+        """Test _story_sort_key handles sub-stories like 3a, 3a-ii."""
+        story_3 = EpicStory(number="10.3", title="Base")
+        story_3a = EpicStory(number="10.3a", title="Sub A")
+        story_3a_ii = EpicStory(number="10.3a-ii", title="Sub A-II")
+        story_3b = EpicStory(number="10.3b", title="Sub B")
+        story_4 = EpicStory(number="10.4", title="Next")
+
+        keys = [_story_sort_key(s) for s in [story_3, story_3a, story_3a_ii, story_3b, story_4]]
+        # Verify natural ordering: 3 < 3a < 3a-ii < 3b < 4
+        assert keys == sorted(keys)
+
+    def test_story_sort_key_letter_suffix(self) -> None:
+        """Test _story_sort_key handles letter suffixes like 4b, 4c."""
+        story_a = EpicStory(number="2.a", title="Test")
+        key = _story_sort_key(story_a)
+        # "a" has no leading digits, so base_num=0
+        assert key[0] == 0
+        assert key[1] == 2
 
     def test_flatten_stories_warns_on_duplicates(self, caplog: pytest.LogCaptureFixture) -> None:
         """Test _flatten_stories logs warning for duplicate stories."""
@@ -1152,6 +1162,16 @@ class TestHelperFunctions:
         assert _parse_sprint_status_key("1-1-project-init") == "1.1"
         assert _parse_sprint_status_key("2-3-state-reader") == "2.3"
         assert _parse_sprint_status_key("12-15-large-numbers") == "12.15"
+
+    def test_parse_sprint_status_key_substories(self) -> None:
+        """Test _parse_sprint_status_key with sub-story keys."""
+        assert _parse_sprint_status_key("10-3a-implement-command-registry") == "10.3a"
+        assert _parse_sprint_status_key("10-3a-ii-implement-tab-completion") == "10.3a-ii"
+        assert _parse_sprint_status_key("10-3a-iii-implement-slash-commands") == "10.3a-iii"
+        assert _parse_sprint_status_key("10-3b-implement-chat-pane") == "10.3b"
+        assert _parse_sprint_status_key("2-3b-implement-securememfile") == "2.3b"
+        assert _parse_sprint_status_key("8-2c-implement-scheduler") == "8.2c"
+        assert _parse_sprint_status_key("1-5a-initialize-testing") == "1.5a"
 
     def test_parse_sprint_status_key_skips_epic_keys(self) -> None:
         """Test _parse_sprint_status_key skips epic keys."""

--- a/tests/bmad/test_substory_parsing.py
+++ b/tests/bmad/test_substory_parsing.py
@@ -1,0 +1,185 @@
+"""Tests for sub-story parsing support.
+
+Verifies that stories with alphanumeric suffixes (3a, 3a-ii, 4b, etc.)
+are correctly parsed from epic files and sprint-status.yaml.
+"""
+
+
+from bmad_assist.bmad.parser import STORY_HEADER_PATTERN, EpicDocument, EpicStory
+from bmad_assist.bmad.state_reader import (
+    _flatten_stories,
+    _natural_story_sort_key,
+    _parse_sprint_status_key,
+)
+
+
+class TestStoryHeaderPattern:
+    """Test STORY_HEADER_PATTERN regex with sub-stories."""
+
+    def test_matches_standard_numeric(self) -> None:
+        """Standard numeric stories match."""
+        m = STORY_HEADER_PATTERN.search("### Story 10.1: Implement Shell")
+        assert m is not None
+        assert m.group(1) == "10"
+        assert m.group(2) == "1"
+        assert m.group(3) == "Implement Shell"
+
+    def test_matches_letter_suffix(self) -> None:
+        """Letter-suffixed stories match (3a, 4b)."""
+        m = STORY_HEADER_PATTERN.search("### Story 10.3a: Command Registry")
+        assert m is not None
+        assert m.group(1) == "10"
+        assert m.group(2) == "3a"
+        assert m.group(3) == "Command Registry"
+
+    def test_matches_hyphenated_suffix(self) -> None:
+        """Hyphenated sub-stories match (3a-ii, 3a-iii)."""
+        m = STORY_HEADER_PATTERN.search("### Story 10.3a-ii: Tab Completion")
+        assert m is not None
+        assert m.group(1) == "10"
+        assert m.group(2) == "3a-ii"
+
+    def test_matches_triple_hyphenated(self) -> None:
+        """Triple-part sub-stories match (3a-iii)."""
+        m = STORY_HEADER_PATTERN.search("### Story 10.3a-iii: Slash Commands")
+        assert m is not None
+        assert m.group(2) == "3a-iii"
+
+    def test_matches_multi_digit(self) -> None:
+        """Multi-digit story numbers match (10.10)."""
+        m = STORY_HEADER_PATTERN.search("### Story 10.10: Onboarding")
+        assert m is not None
+        assert m.group(2) == "10"
+
+    def test_matches_various_header_levels(self) -> None:
+        """Works with ##, ###, ####."""
+        for level in ("##", "###", "####"):
+            m = STORY_HEADER_PATTERN.search(f"{level} Story 2.3b: Title")
+            assert m is not None, f"Failed for header level {level}"
+            assert m.group(2) == "3b"
+
+    def test_matches_all_real_substories(self) -> None:
+        """Verify all known sub-story formats from the user's epics.md."""
+        cases = [
+            ("### Story 1.5a: Initialize Testing", "1", "5a"),
+            ("### Story 2.3b: SecureMemFile", "2", "3b"),
+            ("### Story 2.3c: Memory Protection", "2", "3c"),
+            ("### Story 3.3a: Office365 OAuth", "3", "3a"),
+            ("### Story 3.3b: Office365 EWS", "3", "3b"),
+            ("### Story 3.3c: Office365 OWA", "3", "3c"),
+            ("### Story 4.1a: LLM Runtime", "4", "1a"),
+            ("### Story 8.2a: Core Scheduler", "8", "2a"),
+            ("### Story 8.2b: Catch-Up", "8", "2b"),
+            ("### Story 8.2c: Timezone", "8", "2c"),
+            ("### Story 10.3a: Command Registry", "10", "3a"),
+            ("### Story 10.3a-ii: Tab Completion", "10", "3a-ii"),
+            ("### Story 10.3a-iii: Slash Commands", "10", "3a-iii"),
+            ("### Story 10.3b: Inline Confirmation", "10", "3b"),
+            ("### Story 10.3c: Feedback Loop", "10", "3c"),
+            ("### Story 10.3d: NL Actions", "10", "3d"),
+            ("### Story 10.3e: Workflow Rendering", "10", "3e"),
+            ("### Story 10.4b: Draft Display", "10", "4b"),
+            ("### Story 10.4c: Journal Display", "10", "4c"),
+            ("### Story 10.4d: Calendar Display", "10", "4d"),
+            ("### Story 11.2a: Auto-Pair IPC", "11", "2a"),
+            ("### Story 11.2b: Remote Token", "11", "2b"),
+            ("### Story 11.2c: Manual Key", "11", "2c"),
+            ("### Story 11.2d: Cross-Signing", "11", "2d"),
+            ("### Story 12.1b: Desktop Panes", "12", "1b"),
+            ("### Story 12.1c: Desktop Theme", "12", "1c"),
+            ("### Story 12.1d: Desktop Integration", "12", "1d"),
+        ]
+        for header, expected_epic, expected_story in cases:
+            m = STORY_HEADER_PATTERN.search(header)
+            assert m is not None, f"Failed to match: {header}"
+            assert m.group(1) == expected_epic, f"Epic mismatch for {header}"
+            assert m.group(2) == expected_story, f"Story mismatch for {header}"
+
+    def test_no_match_for_invalid(self) -> None:
+        """Non-story headers don't match."""
+        assert STORY_HEADER_PATTERN.search("## Epic 10: TUI") is None
+        assert STORY_HEADER_PATTERN.search("# Story 10.1: Title") is None  # single #
+
+
+class TestNaturalStorySortKey:
+    """Test _natural_story_sort_key ordering."""
+
+    def test_pure_numeric_ordering(self) -> None:
+        """Pure numeric: 1 < 2 < 10."""
+        assert _natural_story_sort_key("1") < _natural_story_sort_key("2")
+        assert _natural_story_sort_key("2") < _natural_story_sort_key("10")
+
+    def test_letter_suffix_after_numeric(self) -> None:
+        """Letter suffix sorts after base: 3 < 3a < 3b."""
+        assert _natural_story_sort_key("3") < _natural_story_sort_key("3a")
+        assert _natural_story_sort_key("3a") < _natural_story_sort_key("3b")
+
+    def test_hyphenated_after_base_letter(self) -> None:
+        """Hyphenated sorts after base letter: 3a < 3a-ii < 3a-iii."""
+        assert _natural_story_sort_key("3a") < _natural_story_sort_key("3a-ii")
+        assert _natural_story_sort_key("3a-ii") < _natural_story_sort_key("3a-iii")
+
+    def test_full_ordering(self) -> None:
+        """Complete ordering: 3 < 3a < 3a-ii < 3a-iii < 3b < 3c < 4."""
+        keys = ["3", "3a", "3a-ii", "3a-iii", "3b", "3c", "4"]
+        sorted_keys = sorted(keys, key=_natural_story_sort_key)
+        assert sorted_keys == keys
+
+    def test_real_epic10_ordering(self) -> None:
+        """Verify ordering of actual epic 10 story parts."""
+        parts = [
+            "1", "2", "3", "3a", "3a-ii", "3a-iii", "3b", "3c",
+            "3d", "3e", "4", "4b", "4c", "4d", "5", "6", "7",
+            "8", "9", "10",
+        ]
+        sorted_parts = sorted(parts, key=_natural_story_sort_key)
+        assert sorted_parts == parts
+
+
+class TestFlattenStoriesWithSubstories:
+    """Test _flatten_stories ordering with sub-stories."""
+
+    def test_sorts_substories_correctly(self) -> None:
+        """Sub-stories sort in natural order within their epic."""
+        epic = EpicDocument(
+            epic_num=10,
+            title="Epic 10",
+            status=None,
+            stories=[
+                EpicStory(number="10.4b", title="Draft Display"),
+                EpicStory(number="10.3", title="Chat Pane"),
+                EpicStory(number="10.3a", title="Command Registry"),
+                EpicStory(number="10.4", title="Dynamic View"),
+                EpicStory(number="10.3a-ii", title="Tab Completion"),
+                EpicStory(number="10.1", title="Shell"),
+            ],
+            path="epic-10.md",
+        )
+        result = _flatten_stories([epic])
+        numbers = [s.number for s in result]
+        assert numbers == [
+            "10.1", "10.3", "10.3a", "10.3a-ii", "10.4", "10.4b",
+        ]
+
+
+class TestSprintStatusSubstories:
+    """Test sprint-status.yaml parsing with sub-stories."""
+
+    def test_parse_all_substory_key_formats(self) -> None:
+        """All sprint-status key formats for sub-stories parse correctly."""
+        assert _parse_sprint_status_key("10-3a-implement-registry") == "10.3a"
+        assert _parse_sprint_status_key("10-3a-ii-implement-tab") == "10.3a-ii"
+        assert _parse_sprint_status_key("10-3a-iii-implement-slash") == "10.3a-iii"
+        assert _parse_sprint_status_key("2-3b-implement-securememfile") == "2.3b"
+        assert _parse_sprint_status_key("8-2c-implement-scheduler") == "8.2c"
+        assert _parse_sprint_status_key("1-5a-initialize-testing") == "1.5a"
+
+    def test_numeric_keys_still_work(self) -> None:
+        """Standard numeric keys continue to work."""
+        assert _parse_sprint_status_key("1-1-project-init") == "1.1"
+        assert _parse_sprint_status_key("10-10-implement-onboarding") == "10.10"
+
+    def test_module_epic_keys_work(self) -> None:
+        """Module-prefixed keys still parse correctly."""
+        assert _parse_sprint_status_key("qs1-security-infrastructure") is None
+        # qs1 starts with non-digit so won't match the regex; that's fine

--- a/tests/code_review/test_orchestrator.py
+++ b/tests/code_review/test_orchestrator.py
@@ -368,3 +368,160 @@ class TestRunCodeReviewPhaseInsufficientReviewers:
                 )
 
             assert exc_info.value.count < exc_info.value.minimum
+
+
+# ============================================================================
+# Provider-error log cleanliness (Task 16)
+# ============================================================================
+#
+# _invoke_reviewer used to log full tracebacks on ANY exception, including
+# expected provider-layer failures like auth errors or quota exhaustion.
+# On a multi-LLM run, that meant ~50 lines of stack trace per reviewer
+# failure — useless noise that drowned real diagnostics. The fix splits
+# the handler so ProviderError → clean message, other exceptions → keep
+# the traceback (since those indicate actual bugs).
+
+
+import logging
+
+from bmad_assist.code_review.orchestrator import _invoke_reviewer
+from bmad_assist.core.exceptions import (
+    ProviderError,
+    ProviderExitCodeError,
+    ProviderTimeoutError,
+)
+from bmad_assist.providers.base import ExitStatus
+
+
+class TestInvokeReviewerErrorLogging:
+    """_invoke_reviewer logs provider errors cleanly, other errors with traceback."""
+
+    @pytest.fixture
+    def mock_provider(self) -> MagicMock:
+        provider = MagicMock()
+        provider.provider_name = "mock-provider"
+        return provider
+
+    async def _invoke(self, provider: MagicMock) -> tuple:
+        return await _invoke_reviewer(
+            provider=provider,
+            prompt="<compiled/>",
+            timeout=60,
+            reviewer_id="mock-reviewer",
+            model="mock-model",
+            timeout_retries=None,
+            display_model="mock-display",
+        )
+
+    @pytest.mark.asyncio
+    async def test_provider_exit_code_error_logged_without_traceback(
+        self,
+        mock_provider: MagicMock,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Auth errors (ProviderExitCodeError) log clean single-line warning."""
+        mock_provider.invoke.side_effect = ProviderExitCodeError(
+            "Cursor Agent CLI failed with exit code 1: "
+            "Error: Authentication required. Please run 'agent login' first.",
+            exit_code=1,
+            exit_status=ExitStatus.ERROR,
+            stderr="Authentication required",
+            stdout="",
+            command=("cursor-agent",),
+        )
+
+        with caplog.at_level(
+            logging.WARNING, logger="bmad_assist.code_review.orchestrator"
+        ):
+            reviewer_id, output, metrics, error_msg = await self._invoke(mock_provider)
+
+        assert reviewer_id == "mock-reviewer"
+        assert output is None
+        assert metrics is None
+        assert error_msg is not None
+        assert "Authentication required" in error_msg
+        # No traceback dumped — caplog records have exc_info=None
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert warnings, "expected at least one warning log"
+        provider_warnings = [
+            r for r in warnings if "mock-reviewer failed" in r.getMessage()
+        ]
+        assert provider_warnings, "expected the 'Reviewer X failed' warning"
+        assert all(
+            r.exc_info is None for r in provider_warnings
+        ), "ProviderError should log WITHOUT traceback"
+
+    @pytest.mark.asyncio
+    async def test_provider_timeout_error_logged_without_traceback(
+        self,
+        mock_provider: MagicMock,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """ProviderTimeoutError also gets clean logging (no exc_info)."""
+        mock_provider.invoke.side_effect = ProviderTimeoutError(
+            "OpenCode CLI timeout after 1800s: ..."
+        )
+
+        with caplog.at_level(
+            logging.WARNING, logger="bmad_assist.code_review.orchestrator"
+        ):
+            _, _, _, error_msg = await self._invoke(mock_provider)
+
+        assert error_msg is not None
+        provider_warnings = [
+            r
+            for r in caplog.records
+            if r.levelname == "WARNING" and "failed" in r.getMessage()
+        ]
+        assert provider_warnings
+        assert all(r.exc_info is None for r in provider_warnings)
+
+    @pytest.mark.asyncio
+    async def test_provider_error_base_class_logged_without_traceback(
+        self,
+        mock_provider: MagicMock,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Any ProviderError subclass — the handler catches the base class."""
+        mock_provider.invoke.side_effect = ProviderError("Network disconnected")
+
+        with caplog.at_level(
+            logging.WARNING, logger="bmad_assist.code_review.orchestrator"
+        ):
+            _, _, _, error_msg = await self._invoke(mock_provider)
+
+        assert error_msg is not None
+        assert "Network disconnected" in error_msg
+        provider_warnings = [
+            r
+            for r in caplog.records
+            if r.levelname == "WARNING" and "failed" in r.getMessage()
+        ]
+        assert provider_warnings
+        assert all(r.exc_info is None for r in provider_warnings)
+
+    @pytest.mark.asyncio
+    async def test_unexpected_exception_keeps_traceback(
+        self,
+        mock_provider: MagicMock,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Non-Provider exceptions (bugs) must still log with traceback."""
+        mock_provider.invoke.side_effect = RuntimeError("surprise bug")
+
+        with caplog.at_level(
+            logging.WARNING, logger="bmad_assist.code_review.orchestrator"
+        ):
+            _, _, _, error_msg = await self._invoke(mock_provider)
+
+        assert error_msg is not None
+        provider_warnings = [
+            r
+            for r in caplog.records
+            if r.levelname == "WARNING" and "failed" in r.getMessage()
+        ]
+        assert provider_warnings
+        # Unexpected exceptions retain exc_info for debuggability.
+        assert any(
+            r.exc_info is not None for r in provider_warnings
+        ), "RuntimeError should log WITH traceback"

--- a/tests/compiler/test_source_context.py
+++ b/tests/compiler/test_source_context.py
@@ -445,3 +445,274 @@ class TestTruncation:
         content = list(result.values())[0]
         assert len(content) < len(large_content)
         assert "truncated" in content.lower()
+
+
+# =============================================================================
+# Synthesis source file capping with compression
+# =============================================================================
+#
+# Tests for cap_synthesis_source_files — replaces the old hard-cap-and-drop
+# behavior in validate_story_synthesis / code_review_synthesis with
+# compression-aware trimming for markdown and drop-only for source code.
+
+
+from unittest.mock import patch
+
+from bmad_assist.compiler.source_context import (
+    SynthesisCapResult,
+    cap_synthesis_source_files,
+)
+
+
+class TestCapSynthesisSourceFiles:
+    """cap_synthesis_source_files preserves top-N and compresses markdown tail."""
+
+    def _patch_compress(self, return_content: str):
+        """Mock _compress_or_truncate to return a fixed compressed result."""
+        return patch(
+            "bmad_assist.compiler.strategic_context._compress_or_truncate",
+            return_value=(return_content, max(len(return_content) // 4, 1)),
+        )
+
+    def test_under_cap_returns_all_unchanged(self, tmp_path: Path) -> None:
+        """If input size <= max_files, nothing is capped."""
+        files = {
+            "src/a.py": "a" * 100,
+            "src/b.py": "b" * 100,
+        }
+        result = cap_synthesis_source_files(
+            files, max_files=3, project_root=tmp_path
+        )
+        assert isinstance(result, SynthesisCapResult)
+        assert result.files == files
+        assert result.kept_paths == ["src/a.py", "src/b.py"]
+        assert result.compressed_paths == []
+        assert result.dropped_paths == []
+
+    def test_preserves_top_n_verbatim(self, tmp_path: Path) -> None:
+        """First max_files entries appear in result unchanged."""
+        files = {
+            "top-1.py": "ONE",
+            "top-2.py": "TWO",
+            "top-3.py": "THREE",
+            "overflow.py": "FOUR",
+        }
+        result = cap_synthesis_source_files(
+            files, max_files=3, project_root=tmp_path
+        )
+        assert result.files["top-1.py"] == "ONE"
+        assert result.files["top-2.py"] == "TWO"
+        assert result.files["top-3.py"] == "THREE"
+        # Source code overflow is dropped (never compressed)
+        assert "overflow.py" not in result.files
+        assert result.dropped_paths == ["overflow.py"]
+
+    def test_markdown_overflow_compressed(self, tmp_path: Path) -> None:
+        """Markdown files in the overflow are compressed in place."""
+        # ~1000 tokens of markdown, over the 500-token threshold
+        big_md = "x" * 4000
+        files = {
+            "keep-1.py": "a" * 100,
+            "keep-2.py": "b" * 100,
+            "keep-3.py": "c" * 100,
+            "docs/big.md": big_md,
+        }
+        with self._patch_compress("compressed doc"):
+            result = cap_synthesis_source_files(
+                files, max_files=3, project_root=tmp_path
+            )
+
+        # big.md kept (compressed), not dropped.
+        assert "docs/big.md" in result.files
+        assert result.compressed_paths == ["docs/big.md"]
+        assert result.dropped_paths == []
+        # Content was replaced by the compressed version (with annotation).
+        assert "compressed doc" in result.files["docs/big.md"]
+        assert "compressed from" in result.files["docs/big.md"]
+        # Original content is gone.
+        assert big_md not in result.files["docs/big.md"]
+
+    def test_source_code_overflow_always_dropped(self, tmp_path: Path) -> None:
+        """Source code in overflow is dropped, not compressed."""
+        big_py = "x" * 4000
+        files = {
+            "keep-1.md": "a" * 100,
+            "keep-2.md": "b" * 100,
+            "keep-3.md": "c" * 100,
+            "src/big.py": big_py,
+        }
+        with patch(
+            "bmad_assist.compiler.strategic_context._compress_or_truncate"
+        ) as mock_compress:
+            result = cap_synthesis_source_files(
+                files, max_files=3, project_root=tmp_path
+            )
+        # Compression must NEVER fire for .py files
+        mock_compress.assert_not_called()
+        assert "src/big.py" not in result.files
+        assert result.dropped_paths == ["src/big.py"]
+        assert result.compressed_paths == []
+
+    def test_tiny_markdown_overflow_dropped(self, tmp_path: Path) -> None:
+        """Markdown below the compressible threshold is dropped, not compressed."""
+        tiny_md = "tiny"  # << 500 tokens
+        files = {
+            "keep-1.py": "a" * 100,
+            "keep-2.py": "b" * 100,
+            "keep-3.py": "c" * 100,
+            "docs/tiny.md": tiny_md,
+        }
+        with patch(
+            "bmad_assist.compiler.strategic_context._compress_or_truncate"
+        ) as mock_compress:
+            result = cap_synthesis_source_files(
+                files, max_files=3, project_root=tmp_path
+            )
+        mock_compress.assert_not_called()
+        assert result.dropped_paths == ["docs/tiny.md"]
+        assert result.compressed_paths == []
+
+    def test_compression_no_op_falls_back_to_drop(self, tmp_path: Path) -> None:
+        """If compression doesn't actually shrink, the file is dropped."""
+        big_md = "y" * 4000
+        files = {
+            "k1.py": "a" * 100,
+            "k2.py": "b" * 100,
+            "k3.py": "c" * 100,
+            "docs/noop.md": big_md,
+        }
+        # Mock returns same content (no shrink)
+        with self._patch_compress(big_md):
+            result = cap_synthesis_source_files(
+                files, max_files=3, project_root=tmp_path
+            )
+        assert result.compressed_paths == []
+        assert result.dropped_paths == ["docs/noop.md"]
+
+    def test_project_root_none_skips_compression_entirely(self) -> None:
+        """When project_root is None, all overflow is dropped."""
+        big_md = "z" * 4000
+        files = {
+            "k1.py": "a" * 100,
+            "k2.py": "b" * 100,
+            "k3.py": "c" * 100,
+            "docs/big.md": big_md,
+        }
+        with patch(
+            "bmad_assist.compiler.strategic_context._compress_or_truncate"
+        ) as mock_compress:
+            result = cap_synthesis_source_files(
+                files, max_files=3, project_root=None
+            )
+        mock_compress.assert_not_called()
+        assert result.dropped_paths == ["docs/big.md"]
+        assert result.compressed_paths == []
+
+    def test_mixed_overflow_markdown_and_code(self, tmp_path: Path) -> None:
+        """Mixed overflow: markdown compressed, source code dropped."""
+        big_md = "m" * 4000
+        big_py = "p" * 4000
+        files = {
+            "k1.py": "a" * 100,
+            "k2.py": "b" * 100,
+            "k3.py": "c" * 100,
+            "docs/info.md": big_md,
+            "src/extra.py": big_py,
+        }
+        with self._patch_compress("summary"):
+            result = cap_synthesis_source_files(
+                files, max_files=3, project_root=tmp_path
+            )
+        assert result.compressed_paths == ["docs/info.md"]
+        assert result.dropped_paths == ["src/extra.py"]
+        assert "docs/info.md" in result.files
+        assert "src/extra.py" not in result.files
+
+    def test_mdx_and_markdown_extensions(self, tmp_path: Path) -> None:
+        """All three extensions (.md, .markdown, .mdx) are compressed."""
+        big = "x" * 4000
+        files = {
+            "k1.py": "keep",
+            "a.md": big,
+            "b.markdown": big,
+            "c.mdx": big,
+        }
+        with self._patch_compress("tiny"):
+            result = cap_synthesis_source_files(
+                files, max_files=1, project_root=tmp_path
+            )
+        assert set(result.compressed_paths) == {"a.md", "b.markdown", "c.mdx"}
+        assert result.dropped_paths == []
+
+    def test_kept_order_matches_input(self, tmp_path: Path) -> None:
+        """kept_paths reflects the input dict order (score ranking)."""
+        files = {
+            "top.py": "a",
+            "mid.py": "b",
+            "low.py": "c",
+            "drop.py": "d",
+        }
+        result = cap_synthesis_source_files(
+            files, max_files=3, project_root=tmp_path
+        )
+        assert result.kept_paths == ["top.py", "mid.py", "low.py"]
+
+    def test_compression_failure_drops_file(self, tmp_path: Path) -> None:
+        """If _compress_or_truncate raises, the file is dropped silently."""
+        big_md = "x" * 4000
+        files = {
+            "k1.py": "a",
+            "k2.py": "b",
+            "k3.py": "c",
+            "docs/broken.md": big_md,
+        }
+        with patch(
+            "bmad_assist.compiler.strategic_context._compress_or_truncate",
+            side_effect=RuntimeError("LLM unavailable"),
+        ):
+            result = cap_synthesis_source_files(
+                files, max_files=3, project_root=tmp_path
+            )
+        assert result.dropped_paths == ["docs/broken.md"]
+        assert result.compressed_paths == []
+
+    def test_compression_logs_info_line(
+        self, tmp_path: Path, caplog
+    ) -> None:
+        """Successful compression emits an info log with before/after tokens."""
+        import logging
+
+        big_md = "x" * 4000
+        files = {
+            "k1.py": "a",
+            "k2.py": "b",
+            "k3.py": "c",
+            "docs/big.md": big_md,
+        }
+        with self._patch_compress("short"), caplog.at_level(logging.INFO):
+            cap_synthesis_source_files(
+                files, max_files=3, project_root=tmp_path
+            )
+        assert "Synthesis compress" in caplog.text
+        assert "docs/big.md" in caplog.text
+
+    def test_negative_max_files_raises(self, tmp_path: Path) -> None:
+        """max_files must be non-negative."""
+        with pytest.raises(ValueError, match="max_files"):
+            cap_synthesis_source_files(
+                {"a.py": "x"}, max_files=-1, project_root=tmp_path
+            )
+
+    def test_zero_max_files_drops_everything(self, tmp_path: Path) -> None:
+        """max_files=0 drops all non-markdown and compresses all markdown."""
+        files = {
+            "a.py": "x" * 100,
+            "b.md": "y" * 4000,
+        }
+        with self._patch_compress("tiny"):
+            result = cap_synthesis_source_files(
+                files, max_files=0, project_root=tmp_path
+            )
+        assert result.kept_paths == []
+        assert "a.py" in result.dropped_paths
+        assert "b.md" in result.compressed_paths

--- a/tests/compiler/test_source_context.py
+++ b/tests/compiler/test_source_context.py
@@ -465,7 +465,7 @@ from bmad_assist.compiler.source_context import (
 
 
 class TestCapSynthesisSourceFiles:
-    """cap_synthesis_source_files preserves top-N and compresses markdown tail."""
+    """cap_synthesis_source_files compresses every eligible file."""
 
     def _patch_compress(self, return_content: str):
         """Mock _compress_or_truncate to return a fixed compressed result."""
@@ -474,129 +474,180 @@ class TestCapSynthesisSourceFiles:
             return_value=(return_content, max(len(return_content) // 4, 1)),
         )
 
-    def test_under_cap_returns_all_unchanged(self, tmp_path: Path) -> None:
-        """If input size <= max_files, nothing is capped."""
-        files = {
-            "src/a.py": "a" * 100,
-            "src/b.py": "b" * 100,
-        }
-        result = cap_synthesis_source_files(
-            files, max_files=3, project_root=tmp_path
-        )
-        assert isinstance(result, SynthesisCapResult)
-        assert result.files == files
-        assert result.kept_paths == ["src/a.py", "src/b.py"]
-        assert result.compressed_paths == []
-        assert result.dropped_paths == []
+    # ------------------------------------------------------------------
+    # Core behavior: compress all files above threshold, regardless of
+    # type and regardless of position in the score order
+    # ------------------------------------------------------------------
 
-    def test_preserves_top_n_verbatim(self, tmp_path: Path) -> None:
-        """First max_files entries appear in result unchanged."""
-        files = {
-            "top-1.py": "ONE",
-            "top-2.py": "TWO",
-            "top-3.py": "THREE",
-            "overflow.py": "FOUR",
-        }
-        result = cap_synthesis_source_files(
-            files, max_files=3, project_root=tmp_path
-        )
-        assert result.files["top-1.py"] == "ONE"
-        assert result.files["top-2.py"] == "TWO"
-        assert result.files["top-3.py"] == "THREE"
-        # Source code overflow is dropped (never compressed)
-        assert "overflow.py" not in result.files
-        assert result.dropped_paths == ["overflow.py"]
+    def test_all_eligible_files_compressed_including_top_n(
+        self, tmp_path: Path
+    ) -> None:
+        """Every file above the compressibility threshold is compressed.
 
-    def test_markdown_overflow_compressed(self, tmp_path: Path) -> None:
-        """Markdown files in the overflow are compressed in place."""
-        # ~1000 tokens of markdown, over the 500-token threshold
-        big_md = "x" * 4000
+        This is the key semantic change: synthesis doesn't keep the
+        top-N verbatim, it compresses everything because the agent is
+        reasoning over reviewer output, not writing code that needs
+        byte-exact source.
+        """
+        big = "x" * 4000  # > 500 token threshold
         files = {
-            "keep-1.py": "a" * 100,
-            "keep-2.py": "b" * 100,
-            "keep-3.py": "c" * 100,
-            "docs/big.md": big_md,
+            "src/main.py": big,
+            "src/util.py": big,
+            "docs/api.md": big,
         }
-        with self._patch_compress("compressed doc"):
+        with self._patch_compress("compressed body"):
             result = cap_synthesis_source_files(
-                files, max_files=3, project_root=tmp_path
+                files, max_files=5, project_root=tmp_path
             )
-
-        # big.md kept (compressed), not dropped.
-        assert "docs/big.md" in result.files
-        assert result.compressed_paths == ["docs/big.md"]
+        # All three compressed (including the .py files!)
+        assert set(result.compressed_paths) == {
+            "src/main.py",
+            "src/util.py",
+            "docs/api.md",
+        }
         assert result.dropped_paths == []
-        # Content was replaced by the compressed version (with annotation).
-        assert "compressed doc" in result.files["docs/big.md"]
-        assert "compressed from" in result.files["docs/big.md"]
-        # Original content is gone.
-        assert big_md not in result.files["docs/big.md"]
+        # Every result file contains the compressed body + annotation
+        for path, content in result.files.items():
+            assert "compressed body" in content
+            assert "compressed from" in content
+            assert big not in content, f"{path} still contains original content"
 
-    def test_source_code_overflow_always_dropped(self, tmp_path: Path) -> None:
-        """Source code in overflow is dropped, not compressed."""
+    def test_source_code_compressed_in_synthesis_context(
+        self, tmp_path: Path
+    ) -> None:
+        """A .py file over threshold IS compressed (synthesis policy).
+
+        Contrast with the base-handler trim path in dev_story, which
+        would drop .py files — synthesis doesn't write code so it's
+        safe to summarize.
+        """
         big_py = "x" * 4000
+        files = {"src/big.py": big_py}
+        with self._patch_compress("py summary"):
+            result = cap_synthesis_source_files(
+                files, max_files=5, project_root=tmp_path
+            )
+        assert result.compressed_paths == ["src/big.py"]
+        assert "py summary" in result.files["src/big.py"]
+
+    def test_tiny_files_pass_through_verbatim(self, tmp_path: Path) -> None:
+        """Files below the compressibility threshold are kept as-is.
+
+        LLM round-trip overhead outweighs the token savings for small
+        files, so tiny files are included WITHOUT compression.
+        """
+        tiny_py = "def f(): return 1"
+        tiny_md = "# Title\nShort."
         files = {
-            "keep-1.md": "a" * 100,
-            "keep-2.md": "b" * 100,
-            "keep-3.md": "c" * 100,
-            "src/big.py": big_py,
+            "a.py": tiny_py,
+            "b.md": tiny_md,
         }
         with patch(
             "bmad_assist.compiler.strategic_context._compress_or_truncate"
         ) as mock_compress:
             result = cap_synthesis_source_files(
-                files, max_files=3, project_root=tmp_path
+                files, max_files=5, project_root=tmp_path
             )
-        # Compression must NEVER fire for .py files
+        # No LLM calls for tiny files
         mock_compress.assert_not_called()
-        assert "src/big.py" not in result.files
-        assert result.dropped_paths == ["src/big.py"]
+        # Both kept verbatim
+        assert result.files["a.py"] == tiny_py
+        assert result.files["b.md"] == tiny_md
         assert result.compressed_paths == []
+        assert result.included_paths == ["a.py", "b.md"]
 
-    def test_tiny_markdown_overflow_dropped(self, tmp_path: Path) -> None:
-        """Markdown below the compressible threshold is dropped, not compressed."""
-        tiny_md = "tiny"  # << 500 tokens
+    def test_mixed_tiny_and_large_files(self, tmp_path: Path) -> None:
+        """Small files pass through, large files get compressed."""
+        big = "x" * 4000
+        tiny = "tiny"
         files = {
-            "keep-1.py": "a" * 100,
-            "keep-2.py": "b" * 100,
-            "keep-3.py": "c" * 100,
-            "docs/tiny.md": tiny_md,
+            "big.py": big,
+            "tiny.py": tiny,
+            "big.md": big,
+            "tiny.md": tiny,
         }
-        with patch(
-            "bmad_assist.compiler.strategic_context._compress_or_truncate"
-        ) as mock_compress:
+        with self._patch_compress("summary"):
+            result = cap_synthesis_source_files(
+                files, max_files=10, project_root=tmp_path
+            )
+        assert set(result.compressed_paths) == {"big.py", "big.md"}
+        assert result.files["tiny.py"] == tiny
+        assert result.files["tiny.md"] == tiny
+
+    # ------------------------------------------------------------------
+    # max_files still caps the result as an upper bound
+    # ------------------------------------------------------------------
+
+    def test_max_files_applied_after_compression(self, tmp_path: Path) -> None:
+        """Even with compression, max_files caps the total count.
+
+        Input has 5 files, max_files=3 — the 2 lowest-priority entries
+        should be dropped after compression, leaving 3 in the result.
+        """
+        big = "x" * 4000
+        files = {
+            "a.py": big,
+            "b.py": big,
+            "c.py": big,
+            "d.py": big,  # overflow
+            "e.py": big,  # overflow
+        }
+        with self._patch_compress("summary"):
             result = cap_synthesis_source_files(
                 files, max_files=3, project_root=tmp_path
             )
-        mock_compress.assert_not_called()
-        assert result.dropped_paths == ["docs/tiny.md"]
-        assert result.compressed_paths == []
+        assert result.included_paths == ["a.py", "b.py", "c.py"]
+        assert set(result.dropped_paths) == {"d.py", "e.py"}
+        # Top 3 still compressed
+        assert set(result.compressed_paths) == {"a.py", "b.py", "c.py"}
 
-    def test_compression_no_op_falls_back_to_drop(self, tmp_path: Path) -> None:
-        """If compression doesn't actually shrink, the file is dropped."""
-        big_md = "y" * 4000
+    def test_under_cap_all_compressed_none_dropped(
+        self, tmp_path: Path
+    ) -> None:
+        """If input <= max_files, all files are included (but still compressed)."""
+        big = "x" * 4000
         files = {
-            "k1.py": "a" * 100,
-            "k2.py": "b" * 100,
-            "k3.py": "c" * 100,
-            "docs/noop.md": big_md,
+            "a.py": big,
+            "b.md": big,
         }
-        # Mock returns same content (no shrink)
-        with self._patch_compress(big_md):
+        with self._patch_compress("summary"):
+            result = cap_synthesis_source_files(
+                files, max_files=5, project_root=tmp_path
+            )
+        assert len(result.included_paths) == 2
+        assert result.dropped_paths == []
+        assert set(result.compressed_paths) == {"a.py", "b.md"}
+
+    def test_order_preserved_through_cap(self, tmp_path: Path) -> None:
+        """included_paths reflects the input dict (score ranking)."""
+        files = {
+            "top.py": "x" * 4000,
+            "mid.py": "x" * 4000,
+            "low.py": "x" * 4000,
+            "drop.py": "x" * 4000,
+        }
+        with self._patch_compress("s"):
             result = cap_synthesis_source_files(
                 files, max_files=3, project_root=tmp_path
             )
-        assert result.compressed_paths == []
-        assert result.dropped_paths == ["docs/noop.md"]
+        assert result.included_paths == ["top.py", "mid.py", "low.py"]
+        assert result.dropped_paths == ["drop.py"]
 
-    def test_project_root_none_skips_compression_entirely(self) -> None:
-        """When project_root is None, all overflow is dropped."""
-        big_md = "z" * 4000
+    # ------------------------------------------------------------------
+    # Fallback paths: no compression available, compression no-op, etc.
+    # ------------------------------------------------------------------
+
+    def test_project_root_none_falls_back_to_legacy_drop(self) -> None:
+        """When project_root is None, no compression → legacy drop behavior.
+
+        This preserves unit-test ergonomics where callers don't want to
+        depend on the compression machinery.
+        """
         files = {
-            "k1.py": "a" * 100,
-            "k2.py": "b" * 100,
-            "k3.py": "c" * 100,
-            "docs/big.md": big_md,
+            "a.py": "x" * 4000,
+            "b.py": "y" * 4000,
+            "c.py": "z" * 4000,
+            "d.py": "w" * 4000,
         }
         with patch(
             "bmad_assist.compiler.strategic_context._compress_or_truncate"
@@ -605,96 +656,66 @@ class TestCapSynthesisSourceFiles:
                 files, max_files=3, project_root=None
             )
         mock_compress.assert_not_called()
-        assert result.dropped_paths == ["docs/big.md"]
         assert result.compressed_paths == []
+        assert result.included_paths == ["a.py", "b.py", "c.py"]
+        assert result.dropped_paths == ["d.py"]
 
-    def test_mixed_overflow_markdown_and_code(self, tmp_path: Path) -> None:
-        """Mixed overflow: markdown compressed, source code dropped."""
-        big_md = "m" * 4000
-        big_py = "p" * 4000
-        files = {
-            "k1.py": "a" * 100,
-            "k2.py": "b" * 100,
-            "k3.py": "c" * 100,
-            "docs/info.md": big_md,
-            "src/extra.py": big_py,
-        }
-        with self._patch_compress("summary"):
-            result = cap_synthesis_source_files(
-                files, max_files=3, project_root=tmp_path
-            )
-        assert result.compressed_paths == ["docs/info.md"]
-        assert result.dropped_paths == ["src/extra.py"]
-        assert "docs/info.md" in result.files
-        assert "src/extra.py" not in result.files
+    def test_compression_no_op_keeps_file_verbatim(self, tmp_path: Path) -> None:
+        """If compression didn't shrink, file stays in result (unchanged).
 
-    def test_mdx_and_markdown_extensions(self, tmp_path: Path) -> None:
-        """All three extensions (.md, .markdown, .mdx) are compressed."""
-        big = "x" * 4000
-        files = {
-            "k1.py": "keep",
-            "a.md": big,
-            "b.markdown": big,
-            "c.mdx": big,
-        }
-        with self._patch_compress("tiny"):
+        Previous policy dropped no-op files; new policy keeps them
+        because with the "compress all" approach we haven't lost
+        anything by NOT compressing — we still have the original.
+        """
+        content = "y" * 4000
+        files = {"docs/stubborn.md": content}
+        with self._patch_compress(content):  # same-size mock = no-op
             result = cap_synthesis_source_files(
-                files, max_files=1, project_root=tmp_path
+                files, max_files=5, project_root=tmp_path
             )
-        assert set(result.compressed_paths) == {"a.md", "b.markdown", "c.mdx"}
+        assert result.compressed_paths == []
         assert result.dropped_paths == []
+        assert result.files["docs/stubborn.md"] == content
 
-    def test_kept_order_matches_input(self, tmp_path: Path) -> None:
-        """kept_paths reflects the input dict order (score ranking)."""
-        files = {
-            "top.py": "a",
-            "mid.py": "b",
-            "low.py": "c",
-            "drop.py": "d",
-        }
-        result = cap_synthesis_source_files(
-            files, max_files=3, project_root=tmp_path
-        )
-        assert result.kept_paths == ["top.py", "mid.py", "low.py"]
+    def test_compression_failure_keeps_file_verbatim(
+        self, tmp_path: Path
+    ) -> None:
+        """If _compress_or_truncate raises, the file is kept verbatim (not dropped).
 
-    def test_compression_failure_drops_file(self, tmp_path: Path) -> None:
-        """If _compress_or_truncate raises, the file is dropped silently."""
-        big_md = "x" * 4000
-        files = {
-            "k1.py": "a",
-            "k2.py": "b",
-            "k3.py": "c",
-            "docs/broken.md": big_md,
-        }
+        Best-effort compression: a failure on one file shouldn't lose
+        the file entirely. The verbatim content is still useful.
+        """
+        content = "x" * 4000
+        files = {"docs/broken.md": content}
         with patch(
             "bmad_assist.compiler.strategic_context._compress_or_truncate",
             side_effect=RuntimeError("LLM unavailable"),
         ):
             result = cap_synthesis_source_files(
-                files, max_files=3, project_root=tmp_path
+                files, max_files=5, project_root=tmp_path
             )
-        assert result.dropped_paths == ["docs/broken.md"]
         assert result.compressed_paths == []
+        assert result.dropped_paths == []
+        assert result.files["docs/broken.md"] == content
 
     def test_compression_logs_info_line(
         self, tmp_path: Path, caplog
     ) -> None:
-        """Successful compression emits an info log with before/after tokens."""
+        """Successful compression emits an info log."""
         import logging
 
         big_md = "x" * 4000
-        files = {
-            "k1.py": "a",
-            "k2.py": "b",
-            "k3.py": "c",
-            "docs/big.md": big_md,
-        }
+        files = {"docs/big.md": big_md}
         with self._patch_compress("short"), caplog.at_level(logging.INFO):
             cap_synthesis_source_files(
                 files, max_files=3, project_root=tmp_path
             )
         assert "Synthesis compress" in caplog.text
         assert "docs/big.md" in caplog.text
+
+    # ------------------------------------------------------------------
+    # Validation / edge cases
+    # ------------------------------------------------------------------
 
     def test_negative_max_files_raises(self, tmp_path: Path) -> None:
         """max_files must be non-negative."""
@@ -704,15 +725,49 @@ class TestCapSynthesisSourceFiles:
             )
 
     def test_zero_max_files_drops_everything(self, tmp_path: Path) -> None:
-        """max_files=0 drops all non-markdown and compresses all markdown."""
+        """max_files=0 drops all files regardless of type."""
         files = {
-            "a.py": "x" * 100,
+            "a.py": "x" * 4000,
             "b.md": "y" * 4000,
         }
         with self._patch_compress("tiny"):
             result = cap_synthesis_source_files(
                 files, max_files=0, project_root=tmp_path
             )
-        assert result.kept_paths == []
-        assert "a.py" in result.dropped_paths
-        assert "b.md" in result.compressed_paths
+        assert result.included_paths == []
+        assert set(result.dropped_paths) == {"a.py", "b.md"}
+
+    def test_compressed_then_dropped_not_in_compressed_list(
+        self, tmp_path: Path
+    ) -> None:
+        """A file compressed but then dropped by max_files is NOT listed as compressed.
+
+        ``compressed_paths`` is a subset of ``included_paths`` — if we
+        paid the LLM cost but then had to drop the file anyway because
+        of max_files, that path appears in ``dropped_paths`` only.
+        """
+        big = "x" * 4000
+        files = {
+            "top.py": big,
+            "mid.py": big,
+            "low.py": big,
+            "overflow.py": big,  # gets compressed then dropped
+        }
+        with self._patch_compress("summary"):
+            result = cap_synthesis_source_files(
+                files, max_files=3, project_root=tmp_path
+            )
+        assert "overflow.py" not in result.compressed_paths
+        assert "overflow.py" in result.dropped_paths
+        assert set(result.compressed_paths) == {"top.py", "mid.py", "low.py"}
+
+    def test_isinstance_result_type(self, tmp_path: Path) -> None:
+        """Result is a SynthesisCapResult dataclass."""
+        result = cap_synthesis_source_files(
+            {}, max_files=3, project_root=tmp_path
+        )
+        assert isinstance(result, SynthesisCapResult)
+        assert result.files == {}
+        assert result.included_paths == []
+        assert result.compressed_paths == []
+        assert result.dropped_paths == []

--- a/tests/compiler/workflows/test_testarch_atdd.py
+++ b/tests/compiler/workflows/test_testarch_atdd.py
@@ -333,9 +333,9 @@ instructions: "{installed_path}/instructions.md"
             "story_num": "99",
         }
 
-        # Should log warning for missing story (not error - story is optional context)
-        with caplog.at_level(logging.WARNING):
+        # Should log debug message for missing story (not error - story is optional context)
+        with caplog.at_level(logging.DEBUG):
             compile_workflow("testarch-atdd", context)
 
-        # Check warning was logged
+        # Check debug message was logged
         assert "Story file not found" in caplog.text or "99-99" in caplog.text

--- a/tests/core/loop/test_backfill.py
+++ b/tests/core/loop/test_backfill.py
@@ -1,0 +1,184 @@
+"""Tests for backfill mode gap detection and story ordering.
+
+Tests verify that detect_backfill_stories correctly identifies missed
+stories across epics, respects sprint-status exclusions, and returns
+them in natural sort order.
+"""
+
+from bmad_assist.core.loop.backfill import detect_backfill_stories
+
+
+def _loader(stories_by_epic: dict) -> callable:
+    """Create a mock epic_stories_loader from a dict."""
+    def loader(epic_id):
+        return stories_by_epic.get(epic_id, [])
+    return loader
+
+
+class TestDetectBackfillStories:
+    """Test gap detection logic."""
+
+    def test_no_gaps_when_all_completed(self) -> None:
+        """No gaps if all stories before frontier are completed."""
+        stories = {10: ["10.1", "10.2", "10.3"]}
+        gaps = detect_backfill_stories(
+            completed_stories=["10.1", "10.2"],
+            current_story="10.3",
+            epic_list=[10],
+            epic_stories_loader=_loader(stories),
+        )
+        assert gaps == []
+
+    def test_detects_simple_gap(self) -> None:
+        """Detects a story that was skipped."""
+        stories = {10: ["10.1", "10.2", "10.3", "10.4"]}
+        gaps = detect_backfill_stories(
+            completed_stories=["10.1", "10.3"],
+            current_story="10.4",
+            epic_list=[10],
+            epic_stories_loader=_loader(stories),
+        )
+        assert gaps == ["10.2"]
+
+    def test_detects_substory_gaps(self) -> None:
+        """Detects sub-stories that were never seen."""
+        stories = {10: ["10.1", "10.2", "10.3", "10.3a", "10.3b", "10.4"]}
+        gaps = detect_backfill_stories(
+            completed_stories=["10.1", "10.2", "10.3"],
+            current_story="10.4",
+            epic_list=[10],
+            epic_stories_loader=_loader(stories),
+        )
+        assert gaps == ["10.3a", "10.3b"]
+
+    def test_detects_cross_epic_gaps(self) -> None:
+        """Detects gaps from earlier epics."""
+        stories = {
+            1: ["1.1", "1.2", "1.5a"],
+            4: ["4.1", "4.1a"],
+            10: ["10.1", "10.2"],
+        }
+        gaps = detect_backfill_stories(
+            completed_stories=["1.1", "1.2", "4.1", "10.1"],
+            current_story="10.2",
+            epic_list=[1, 4, 10],
+            epic_stories_loader=_loader(stories),
+        )
+        assert gaps == ["1.5a", "4.1a"]
+
+    def test_excludes_done_in_sprint_status(self) -> None:
+        """Stories marked done in sprint-status are not backfilled."""
+        stories = {2: ["2.1", "2.3b", "2.3c"]}
+        gaps = detect_backfill_stories(
+            completed_stories=["2.1"],
+            current_story="2.3c",
+            epic_list=[2],
+            epic_stories_loader=_loader(stories),
+            sprint_statuses={"2.3b": "done"},
+        )
+        assert gaps == []  # 2.3b is done in sprint-status
+
+    def test_excludes_deferred_in_sprint_status(self) -> None:
+        """Stories marked deferred are intentionally skipped."""
+        stories = {4: ["4.1", "4.1a", "4.2"]}
+        gaps = detect_backfill_stories(
+            completed_stories=["4.1"],
+            current_story="4.2",
+            epic_list=[4],
+            epic_stories_loader=_loader(stories),
+            sprint_statuses={"4.1a": "deferred"},
+        )
+        assert gaps == []
+
+    def test_includes_backlog_in_sprint_status(self) -> None:
+        """Stories with backlog status ARE backfilled."""
+        stories = {8: ["8.1", "8.2a", "8.2b", "8.3"]}
+        gaps = detect_backfill_stories(
+            completed_stories=["8.1"],
+            current_story="8.3",
+            epic_list=[8],
+            epic_stories_loader=_loader(stories),
+            sprint_statuses={"8.2a": "backlog", "8.2b": "backlog"},
+        )
+        assert gaps == ["8.2a", "8.2b"]
+
+    def test_stories_after_frontier_excluded(self) -> None:
+        """Stories after the current position are NOT included."""
+        stories = {10: ["10.1", "10.2", "10.3", "10.4", "10.5"]}
+        gaps = detect_backfill_stories(
+            completed_stories=["10.1", "10.2"],
+            current_story="10.3",
+            epic_list=[10],
+            epic_stories_loader=_loader(stories),
+        )
+        # 10.4 and 10.5 come after frontier, must not be included
+        assert gaps == []
+
+    def test_real_world_scenario(self) -> None:
+        """Simulate the user's actual state with epics 1-10."""
+        stories = {
+            1: ["1.1", "1.2", "1.3", "1.4", "1.5", "1.5a", "1.6", "1.7"],
+            4: ["4.1", "4.1a", "4.2", "4.3", "4.4", "4.5"],
+            8: ["8.1", "8.2", "8.2a", "8.2b", "8.2c", "8.3", "8.4", "8.5", "8.6"],
+            10: [
+                "10.1", "10.2", "10.3", "10.3a", "10.3a-ii", "10.3a-iii",
+                "10.3b", "10.3c", "10.3d", "10.3e",
+                "10.4", "10.4b", "10.4c", "10.4d",
+                "10.5", "10.6", "10.7",
+            ],
+        }
+        completed = [
+            "1.1", "1.2", "1.3", "1.4", "1.5", "1.6", "1.7",
+            "4.1", "4.2", "4.3", "4.4", "4.5",
+            "8.1", "8.2", "8.3", "8.4", "8.5", "8.6",
+            "10.1", "10.2", "10.3", "10.4", "10.5", "10.6",
+        ]
+        gaps = detect_backfill_stories(
+            completed_stories=completed,
+            current_story="10.6",
+            epic_list=[1, 4, 8, 10],
+            epic_stories_loader=_loader(stories),
+        )
+        assert gaps == [
+            "1.5a",
+            "4.1a",
+            "8.2a", "8.2b", "8.2c",
+            "10.3a", "10.3a-ii", "10.3a-iii",
+            "10.3b", "10.3c", "10.3d", "10.3e",
+            "10.4b", "10.4c", "10.4d",
+        ]
+
+    def test_natural_sort_order(self) -> None:
+        """Gap stories are returned in natural sort order."""
+        stories = {10: [
+            "10.1", "10.3a-ii", "10.3", "10.3a", "10.3b", "10.4",
+        ]}
+        gaps = detect_backfill_stories(
+            completed_stories=["10.1"],
+            current_story="10.4",
+            epic_list=[10],
+            epic_stories_loader=_loader(stories),
+        )
+        assert gaps == ["10.3", "10.3a", "10.3a-ii", "10.3b"]
+
+    def test_empty_epic_list(self) -> None:
+        """No crash with empty epic list."""
+        gaps = detect_backfill_stories(
+            completed_stories=[],
+            current_story="1.1",
+            epic_list=[],
+            epic_stories_loader=_loader({}),
+        )
+        assert gaps == []
+
+    def test_excludes_cancelled_and_skipped(self) -> None:
+        """Stories with cancelled or skipped status are excluded."""
+        stories = {5: ["5.1", "5.2", "5.3"]}
+        gaps = detect_backfill_stories(
+            completed_stories=[],
+            current_story="5.3",
+            epic_list=[5],
+            epic_stories_loader=_loader(stories),
+            sprint_statuses={"5.1": "cancelled", "5.2": "skipped"},
+        )
+        assert gaps == []

--- a/tests/core/loop/test_backfill.py
+++ b/tests/core/loop/test_backfill.py
@@ -182,3 +182,41 @@ class TestDetectBackfillStories:
             sprint_statuses={"5.1": "cancelled", "5.2": "skipped"},
         )
         assert gaps == []
+
+    def test_frontier_stays_fixed_across_backfill_completions(self) -> None:
+        """Gaps are always relative to the original frontier, not the last backfill story."""
+        stories = {
+            1: ["1.1", "1.5a"],
+            10: ["10.1", "10.3a", "10.3b", "10.6"],
+        }
+        frontier = "10.6"
+        completed = ["1.1", "10.1", "10.6"]
+
+        # First call: 3 gaps detected
+        gaps1 = detect_backfill_stories(
+            completed_stories=completed,
+            current_story=frontier,
+            epic_list=[1, 10],
+            epic_stories_loader=_loader(stories),
+        )
+        assert gaps1 == ["1.5a", "10.3a", "10.3b"]
+
+        # After completing 1.5a, frontier stays at 10.6
+        completed.append("1.5a")
+        gaps2 = detect_backfill_stories(
+            completed_stories=completed,
+            current_story=frontier,  # Same frontier!
+            epic_list=[1, 10],
+            epic_stories_loader=_loader(stories),
+        )
+        assert gaps2 == ["10.3a", "10.3b"]
+
+        # After completing all gaps, empty
+        completed.extend(["10.3a", "10.3b"])
+        gaps3 = detect_backfill_stories(
+            completed_stories=completed,
+            current_story=frontier,
+            epic_list=[1, 10],
+            epic_stories_loader=_loader(stories),
+        )
+        assert gaps3 == []

--- a/tests/core/loop/test_code_review_synthesis_handler.py
+++ b/tests/core/loop/test_code_review_synthesis_handler.py
@@ -1801,3 +1801,202 @@ class TestCompressionPipelineIntegration:
             # Standard custom fields should also be present
             assert saved_record.custom.get("phase") == "code-review-synthesis"
             assert saved_record.custom.get("reviewer_count") == 2  # from cached_reviews fixture
+
+
+# =============================================================================
+# Retry on short synthesis output (model-off-rails recovery)
+# =============================================================================
+#
+# Observed failure mode: LLM emits long preamble OUTSIDE the START/END
+# markers, then emits markers with empty content between them. Extraction
+# correctly returns ~5 chars (between empty markers). Previous behavior
+# failed the phase immediately. New behavior: retry once with a
+# reinforcement note in the prompt, only fail if retry also comes up empty.
+
+
+# Small mock output: START/END markers with nothing meaningful between them —
+# models the actual failure mode seen in production runs.
+_MOCK_EMPTY_MARKERS_OUTPUT = (
+    "Let me verify which iroh API surface is available.\n"
+    "Now I have enough context. Let me apply all the targeted fixes.\n\n"
+    "<!-- CODE_REVIEW_SYNTHESIS_START -->\n"
+    "\n"
+    "<!-- CODE_REVIEW_SYNTHESIS_END -->\n\n"
+    "**Fix 1:** Implement transport/status.rs ...\n"
+    "**Fix 2:** Update the misleading banner ...\n"
+)
+
+
+class TestCodeReviewSynthesisRetryOnShortOutput:
+    """Handler retries once when extraction produces sub-minimum output."""
+
+    def test_first_attempt_succeeds_no_retry(
+        self,
+        synthesis_config: Config,
+        project_with_story: Path,
+        state_for_synthesis: State,
+        cached_reviews: str,
+    ) -> None:
+        """Healthy first attempt → invoke_provider called once."""
+        from bmad_assist.core.loop.handlers.code_review_synthesis import (
+            CodeReviewSynthesisHandler,
+        )
+
+        handler = CodeReviewSynthesisHandler(synthesis_config, project_with_story)
+
+        with (
+            patch.object(handler, "render_prompt") as mock_render,
+            patch.object(handler, "invoke_provider") as mock_invoke,
+            patch("bmad_assist.core.debug_logger.save_prompt"),
+        ):
+            mock_render.return_value = "<compiled>test</compiled>"
+            mock_invoke.return_value = ProviderResult(
+                stdout=_MOCK_SYNTHESIS_OUTPUT,
+                stderr="",
+                exit_code=0,
+                duration_ms=5000,
+                model="opus-4",
+                command=("claude", "--print"),
+            )
+
+            result = handler.execute(state_for_synthesis)
+
+        assert result.success
+        assert mock_invoke.call_count == 1
+
+    def test_short_first_attempt_retries_once_and_succeeds(
+        self,
+        synthesis_config: Config,
+        project_with_story: Path,
+        state_for_synthesis: State,
+        cached_reviews: str,
+    ) -> None:
+        """Empty-markers first attempt → retry → healthy second attempt."""
+        from bmad_assist.core.loop.handlers.code_review_synthesis import (
+            CodeReviewSynthesisHandler,
+        )
+
+        handler = CodeReviewSynthesisHandler(synthesis_config, project_with_story)
+
+        short_result = ProviderResult(
+            stdout=_MOCK_EMPTY_MARKERS_OUTPUT,
+            stderr="",
+            exit_code=0,
+            duration_ms=3000,
+            model="opus-4",
+            command=("claude", "--print"),
+        )
+        healthy_result = ProviderResult(
+            stdout=_MOCK_SYNTHESIS_OUTPUT,
+            stderr="",
+            exit_code=0,
+            duration_ms=5000,
+            model="opus-4",
+            command=("claude", "--print"),
+        )
+
+        with (
+            patch.object(handler, "render_prompt") as mock_render,
+            patch.object(handler, "invoke_provider") as mock_invoke,
+            patch("bmad_assist.core.debug_logger.save_prompt"),
+        ):
+            mock_render.return_value = "<compiled>test</compiled>"
+            mock_invoke.side_effect = [short_result, healthy_result]
+
+            result = handler.execute(state_for_synthesis)
+
+        assert result.success
+        assert mock_invoke.call_count == 2
+        # Second invocation carries the reinforcement note.
+        second_prompt = mock_invoke.call_args_list[1].args[0]
+        assert "IMPORTANT" in second_prompt
+        assert "INSIDE" in second_prompt
+        # First invocation did NOT carry the reinforcement note.
+        first_prompt = mock_invoke.call_args_list[0].args[0]
+        assert "IMPORTANT" not in first_prompt or "INSIDE" not in first_prompt.upper()
+
+    def test_both_attempts_short_fails_with_marker_diagnostics(
+        self,
+        synthesis_config: Config,
+        project_with_story: Path,
+        state_for_synthesis: State,
+        cached_reviews: str,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Short output after retry → fail with marker-position diagnostics."""
+        import logging as _logging
+
+        from bmad_assist.core.loop.handlers.code_review_synthesis import (
+            CodeReviewSynthesisHandler,
+        )
+
+        handler = CodeReviewSynthesisHandler(synthesis_config, project_with_story)
+
+        short_result = ProviderResult(
+            stdout=_MOCK_EMPTY_MARKERS_OUTPUT,
+            stderr="",
+            exit_code=0,
+            duration_ms=3000,
+            model="opus-4",
+            command=("claude", "--print"),
+        )
+
+        with (
+            patch.object(handler, "render_prompt") as mock_render,
+            patch.object(handler, "invoke_provider") as mock_invoke,
+            patch("bmad_assist.core.debug_logger.save_prompt"),
+            caplog.at_level(
+                _logging.ERROR,
+                logger="bmad_assist.core.loop.handlers.code_review_synthesis",
+            ),
+        ):
+            mock_render.return_value = "<compiled>test</compiled>"
+            mock_invoke.side_effect = [short_result, short_result]
+
+            result = handler.execute(state_for_synthesis)
+
+        assert not result.success
+        assert mock_invoke.call_count == 2
+        # Error surfaces the marker diagnostics (START@, END@, content between).
+        error_logs = [r.getMessage() for r in caplog.records if r.levelname == "ERROR"]
+        assert any("Markers:" in msg for msg in error_logs)
+        assert any("content between=" in msg for msg in error_logs)
+        # Error message mentions retry count.
+        assert "2 attempts" in (result.error or "")
+
+    def test_first_attempt_exit_code_failure_no_retry(
+        self,
+        synthesis_config: Config,
+        project_with_story: Path,
+        state_for_synthesis: State,
+        cached_reviews: str,
+    ) -> None:
+        """Provider-level failure (exit_code != 0) → no retry, fail fast."""
+        from bmad_assist.core.loop.handlers.code_review_synthesis import (
+            CodeReviewSynthesisHandler,
+        )
+
+        handler = CodeReviewSynthesisHandler(synthesis_config, project_with_story)
+
+        crash_result = ProviderResult(
+            stdout="",
+            stderr="API error",
+            exit_code=1,
+            duration_ms=500,
+            model="opus-4",
+            command=("claude", "--print"),
+        )
+
+        with (
+            patch.object(handler, "render_prompt") as mock_render,
+            patch.object(handler, "invoke_provider") as mock_invoke,
+            patch("bmad_assist.core.debug_logger.save_prompt"),
+        ):
+            mock_render.return_value = "<compiled>test</compiled>"
+            mock_invoke.return_value = crash_result
+
+            result = handler.execute(state_for_synthesis)
+
+        # Single attempt — provider errors aren't "short output" retryable.
+        assert not result.success
+        assert mock_invoke.call_count == 1

--- a/tests/core/test_config_tool_guard_defaults.py
+++ b/tests/core/test_config_tool_guard_defaults.py
@@ -1,0 +1,35 @@
+"""Tests for ToolCallGuard config defaults (Fix #2)."""
+
+import pytest
+from pydantic import ValidationError
+
+from bmad_assist.core.config.models.features import ToolGuardConfig
+
+
+class TestToolGuardDefaults:
+    """Verify ToolGuardConfig defaults after Fix #2."""
+
+    def test_default_max_interactions_per_file_is_40(self) -> None:
+        """Fix #2: Default raised from 25 to 40."""
+        config = ToolGuardConfig()
+        assert config.max_interactions_per_file == 40
+
+    def test_default_max_total_calls_unchanged(self) -> None:
+        """max_total_calls default remains 300."""
+        config = ToolGuardConfig()
+        assert config.max_total_calls == 300
+
+    def test_default_max_calls_per_minute_unchanged(self) -> None:
+        """max_calls_per_minute default remains 90."""
+        config = ToolGuardConfig()
+        assert config.max_calls_per_minute == 90
+
+    def test_custom_max_interactions_per_file(self) -> None:
+        """Custom value overrides default."""
+        config = ToolGuardConfig(max_interactions_per_file=50)
+        assert config.max_interactions_per_file == 50
+
+    def test_min_validation_rejects_zero(self) -> None:
+        """max_interactions_per_file must be >= 1."""
+        with pytest.raises(ValidationError):
+            ToolGuardConfig(max_interactions_per_file=0)

--- a/tests/core/test_extraction_termination.py
+++ b/tests/core/test_extraction_termination.py
@@ -1,0 +1,89 @@
+"""Tests for extraction with termination_reason (Fix #4)."""
+
+import logging
+
+from bmad_assist.core.extraction import (
+    ReportMarkers,
+    extract_report,
+)
+
+_TEST_MARKERS = ReportMarkers(
+    start_marker="<!-- TEST_START -->",
+    end_marker="<!-- TEST_END -->",
+    fallback_patterns=[r"^## Report"],
+    name="test-report",
+)
+
+
+class TestExtractionTerminationReason:
+    """Test termination_reason parameter in extract_report."""
+
+    def test_guard_terminated_logs_distinct_warning(self, caplog) -> None:
+        """Guard-terminated extraction logs ToolCallGuard-specific warning."""
+        raw = "some incomplete output without markers"
+        with caplog.at_level(logging.WARNING):
+            result = extract_report(
+                raw,
+                _TEST_MARKERS,
+                termination_reason="guard:file_interaction_cap:foo.md(would_be_26/25)",
+            )
+        assert result == raw.strip()
+        assert "ToolCallGuard terminated" in caplog.text
+        assert "guard:file_interaction_cap" in caplog.text
+
+    def test_no_termination_reason_logs_generic_warning(self, caplog) -> None:
+        """Without termination_reason, logs generic extraction warning."""
+        raw = "some output without markers"
+        with caplog.at_level(logging.WARNING):
+            result = extract_report(raw, _TEST_MARKERS)
+        assert result == raw.strip()
+        assert "Could not extract structured" in caplog.text
+        assert "ToolCallGuard" not in caplog.text
+
+    def test_markers_present_ignores_termination_reason(self, caplog) -> None:
+        """When markers found, termination_reason is irrelevant."""
+        raw = (
+            "preamble\n<!-- TEST_START -->\nReport content\n"
+            "<!-- TEST_END -->\npostamble"
+        )
+        with caplog.at_level(logging.WARNING):
+            result = extract_report(
+                raw,
+                _TEST_MARKERS,
+                termination_reason="guard:file_interaction_cap:foo(26/25)",
+            )
+        assert result == "Report content"
+        assert "ToolCallGuard" not in caplog.text
+        assert "Could not extract" not in caplog.text
+
+    def test_fallback_pattern_ignores_termination_reason(self, caplog) -> None:
+        """When fallback pattern matches, termination_reason is irrelevant."""
+        raw = "some text\n## Report\nReport body here"
+        with caplog.at_level(logging.WARNING):
+            result = extract_report(
+                raw,
+                _TEST_MARKERS,
+                termination_reason="guard:budget_exceeded",
+            )
+        assert "Report body here" in result
+        assert "ToolCallGuard" not in caplog.text
+
+    def test_termination_reason_none_default(self, caplog) -> None:
+        """Default termination_reason=None behaves like pre-fix behavior."""
+        raw = "raw output"
+        with caplog.at_level(logging.WARNING):
+            result = extract_report(raw, _TEST_MARKERS, termination_reason=None)
+        assert result == raw.strip()
+        assert "Could not extract structured" in caplog.text
+
+    def test_non_guard_termination_reason_uses_generic(self, caplog) -> None:
+        """Non-guard termination reasons use generic warning."""
+        raw = "output without markers"
+        with caplog.at_level(logging.WARNING):
+            extract_report(
+                raw,
+                _TEST_MARKERS,
+                termination_reason="some_other_reason",
+            )
+        assert "Could not extract structured" in caplog.text
+        assert "ToolCallGuard" not in caplog.text

--- a/tests/core/test_helper_timeout_config.py
+++ b/tests/core/test_helper_timeout_config.py
@@ -1,0 +1,32 @@
+"""Tests for helper provider timeout configuration."""
+
+from bmad_assist.core.config.models.providers import HelperProviderConfig
+
+
+class TestHelperProviderTimeout:
+    """Test configurable timeout for helper LLM provider."""
+
+    def test_default_timeout_is_120(self) -> None:
+        """Default helper timeout is 120 seconds."""
+        config = HelperProviderConfig()
+        assert config.timeout == 120
+
+    def test_custom_timeout_from_config(self) -> None:
+        """Custom timeout value can be set."""
+        config = HelperProviderConfig(timeout=180)
+        assert config.timeout == 180
+
+    def test_minimum_timeout_is_10(self) -> None:
+        """Timeout must be at least 10 seconds."""
+        import pytest
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            HelperProviderConfig(timeout=5)
+
+    def test_timeout_used_in_provider_config(self) -> None:
+        """Verify timeout is accessible alongside model and provider."""
+        config = HelperProviderConfig(provider="claude", model="haiku", timeout=90)
+        assert config.provider == "claude"
+        assert config.model == "haiku"
+        assert config.timeout == 90

--- a/tests/core/test_prompt_budget_trimming.py
+++ b/tests/core/test_prompt_budget_trimming.py
@@ -28,12 +28,16 @@ class TestTrimSourceContext:
     """Test _trim_source_context budget enforcement."""
 
     def test_no_trimming_when_within_budget(self) -> None:
-        """Prompt within budget returned unchanged."""
+        """Prompt within budget returned unchanged with empty removed/compressed lists."""
         prompt = _make_prompt(3, content_size=100)
         current_tokens = len(prompt) // 4
         budget = current_tokens + 1000  # Well within budget
-        result = _trim_source_context(prompt, current_tokens, budget)
+        result, removed, compressed = _trim_source_context(
+            prompt, current_tokens, budget
+        )
         assert result == prompt
+        assert removed == []
+        assert compressed == []
 
     def test_trims_last_file_when_over_budget(self) -> None:
         """Slightly over budget removes last (lowest priority) file."""
@@ -41,10 +45,14 @@ class TestTrimSourceContext:
         current_tokens = len(prompt) // 4
         # Set budget to be less than current but achievable by removing 1 file
         budget = current_tokens - 400  # ~2000/4 = 500 tokens per file
-        result = _trim_source_context(prompt, current_tokens, budget)
+        result, removed, compressed = _trim_source_context(
+            prompt, current_tokens, budget
+        )
         assert "file_3.py" not in result
         assert "file_1.py" in result
         assert "file_2.py" in result
+        assert "src/file_3.py" in removed
+        assert compressed == []  # .py files never compressed
 
     def test_trims_multiple_files_when_significantly_over(self) -> None:
         """Significantly over budget removes multiple lowest-priority files."""
@@ -52,26 +60,35 @@ class TestTrimSourceContext:
         current_tokens = len(prompt) // 4
         # Budget achievable only by removing 3+ files
         budget = current_tokens - 1200
-        result = _trim_source_context(prompt, current_tokens, budget)
+        result, removed, _compressed = _trim_source_context(
+            prompt, current_tokens, budget
+        )
         # file_1 should always survive (highest priority)
         assert "file_1.py" in result
         # At least one file was removed
         assert len(result) < len(prompt)
+        assert len(removed) >= 1
+        # Lowest-priority files trimmed first (reverse order of source list).
+        assert "src/file_5.py" in removed
 
     def test_preserves_non_source_content(self) -> None:
         """Strategic context and mission are never trimmed."""
         prompt = _make_prompt(3, content_size=2000)
         current_tokens = len(prompt) // 4
         budget = current_tokens - 800
-        result = _trim_source_context(prompt, current_tokens, budget)
+        result, _removed, _compressed = _trim_source_context(
+            prompt, current_tokens, budget
+        )
         assert "<mission>Do something</mission>" in result
         assert "<compiled-workflow>" in result
 
     def test_no_crash_on_missing_context(self) -> None:
-        """Prompt without any <file> blocks returns unchanged."""
+        """Prompt without any <file> blocks returns unchanged + empty lists."""
         prompt = "<compiled-workflow><mission>test</mission></compiled-workflow>"
-        result = _trim_source_context(prompt, 100, 50)
+        result, removed, compressed = _trim_source_context(prompt, 100, 50)
         assert result == prompt
+        assert removed == []
+        assert compressed == []
 
     def test_logs_removed_files(self, caplog) -> None:
         """Each removed file is logged."""
@@ -88,6 +105,356 @@ class TestTrimSourceContext:
         prompt = _make_prompt(4, content_size=4000)
         current_tokens = len(prompt) // 4
         budget = current_tokens // 2
-        result = _trim_source_context(prompt, current_tokens, budget)
+        result, _removed, _compressed = _trim_source_context(
+            prompt, current_tokens, budget
+        )
         new_tokens = len(result) // 4
         assert new_tokens < current_tokens
+
+    def test_returns_removed_paths_in_trim_order(self) -> None:
+        """Return value's `removed` list reflects the order paths were trimmed.
+
+        Paths are trimmed from the lowest-priority end of the file list,
+        so file_N is removed before file_(N-1). Callers (e.g. handler base)
+        feed this list into ToolCallGuard so the model can read the trimmed
+        files via tool calls without hitting the per-file cap.
+        """
+        prompt = _make_prompt(4, content_size=2000)
+        current_tokens = len(prompt) // 4
+        budget = current_tokens - 1200  # forces ~2 trims
+        _result, removed, _compressed = _trim_source_context(
+            prompt, current_tokens, budget
+        )
+        assert removed, "expected at least one trim"
+        # Lowest-priority (highest index) trimmed first.
+        assert removed[0] == "src/file_4.py"
+        # All entries are repo-relative paths from the XML path attribute.
+        assert all(p.startswith("src/file_") for p in removed)
+
+
+# =============================================================================
+# Markdown compression in budget trim (compression follow-up)
+# =============================================================================
+#
+# Compression delegates to compiler.strategic_context._compress_or_truncate,
+# which is fail-safe (no helper provider → truncation, exception → truncation).
+# Tests mock it where needed so we don't depend on a live LLM.
+
+
+from pathlib import Path
+from unittest.mock import patch
+
+
+def _wrap_cdata(content: str) -> str:
+    """Match the wrapping done by compiler.output._wrap_cdata."""
+    if "]]>" in content:
+        parts = content.split("]]>")
+        return "<![CDATA[\n\n" + "\n\n]]]]><![CDATA[\n\n".join(parts) + "\n\n]]>"
+    return "<![CDATA[\n\n" + content + "\n\n]]>"
+
+
+def _make_md_prompt(files: list[tuple[str, str]]) -> str:
+    """Build a fake prompt with one ``<file>`` block per (path, content) tuple.
+
+    Files appear in the order given; trim iterates them in REVERSE so
+    later entries are dropped/compressed first.
+    """
+    blocks = []
+    for i, (path, content) in enumerate(files, start=1):
+        label = "markdown" if path.endswith((".md", ".markdown", ".mdx")) else "source"
+        blocks.append(
+            f'<file id="f{i}" path="{path}" label="{label}">{_wrap_cdata(content)}</file>'
+        )
+    body = "<context>\n" + "\n".join(blocks) + "\n</context>"
+    return f"<compiled-workflow>\n<mission>Test</mission>\n{body}\n</compiled-workflow>"
+
+
+class TestExtractFileBlockContent:
+    """Round-trip helpers for CDATA wrapping."""
+
+    def test_round_trip_simple_content(self) -> None:
+        from bmad_assist.core.loop.handlers.base import _extract_file_block_content
+
+        block = '<file id="f1" path="docs/foo.md" label="markdown">' + _wrap_cdata("Hello world") + "</file>"
+        assert _extract_file_block_content(block) == "Hello world"
+
+    def test_round_trip_content_with_cdata_close_marker(self) -> None:
+        """Content that itself contains ``]]>`` survives the round-trip."""
+        from bmad_assist.core.loop.handlers.base import _extract_file_block_content
+
+        original = "Pre]]>Post"
+        block = (
+            '<file id="f1" path="docs/foo.md" label="markdown">'
+            + _wrap_cdata(original)
+            + "</file>"
+        )
+        # Recovered text should match the original (the CDATA split is reversed).
+        assert _extract_file_block_content(block) == original
+
+    def test_returns_none_for_malformed_block(self) -> None:
+        from bmad_assist.core.loop.handlers.base import _extract_file_block_content
+
+        # Missing closing tag
+        assert _extract_file_block_content("<file>incomplete") is None
+        # No CDATA wrapping
+        assert (
+            _extract_file_block_content('<file id="f1" path="x">raw</file>') is None
+        )
+
+
+class TestSanitizeDocTypeFromPath:
+    """Cache key derivation."""
+
+    def test_alphanumerics_preserved(self) -> None:
+        from bmad_assist.core.loop.handlers.base import _sanitize_doc_type_from_path
+
+        result = _sanitize_doc_type_from_path("docs/api/v1.md")
+        assert result == "srcmd-docs-api-v1-md"
+
+    def test_special_chars_collapsed(self) -> None:
+        from bmad_assist.core.loop.handlers.base import _sanitize_doc_type_from_path
+
+        result = _sanitize_doc_type_from_path("a/b//c..d")
+        # Multiple separators → single dash; no leading/trailing dashes.
+        assert "--" not in result
+        assert result.startswith("srcmd-")
+        assert not result.endswith("-")
+
+
+class TestMarkdownCompressionInTrim:
+    """Markdown files are compressed in place before being dropped."""
+
+    def _patch_compress(self, return_content: str):
+        """Patch _compress_or_truncate to return a fixed compressed result."""
+        return patch(
+            "bmad_assist.compiler.strategic_context._compress_or_truncate",
+            return_value=(return_content, len(return_content) // 4),
+        )
+
+    def test_markdown_is_compressed_not_dropped(self, tmp_path: Path) -> None:
+        """A markdown file over budget gets compressed in place."""
+        # Big enough to trip the >= 500 token compression threshold
+        big_md_content = "x" * 4000  # ~1000 tokens
+        prompt = _make_md_prompt(
+            [
+                ("src/main.py", "y" * 200),
+                ("docs/big.md", big_md_content),
+            ]
+        )
+        current_tokens = len(prompt) // 4
+        budget = current_tokens - 500  # forces a trim
+
+        compressed_payload = "compressed summary of big.md"
+        with self._patch_compress(compressed_payload):
+            result, removed, compressed = _trim_source_context(
+                prompt, current_tokens, budget, project_root=tmp_path
+            )
+
+        # The markdown file is STILL in the prompt (compressed in place).
+        assert "docs/big.md" in result
+        assert compressed_payload in result
+        # Annotation tells the model it's compressed.
+        assert "compressed from" in result
+        # Original content is gone (replaced).
+        assert big_md_content not in result
+        # Tracked as compressed, not removed.
+        assert compressed == ["docs/big.md"]
+        assert removed == []
+
+    def test_source_code_never_compressed_even_if_eligible_size(
+        self, tmp_path: Path
+    ) -> None:
+        """A .py file over budget is dropped, never compressed."""
+        big_py_content = "x" * 4000
+        prompt = _make_md_prompt(
+            [
+                ("src/keep.py", "y" * 200),
+                ("src/big.py", big_py_content),
+            ]
+        )
+        current_tokens = len(prompt) // 4
+        budget = current_tokens - 500
+
+        with patch(
+            "bmad_assist.compiler.strategic_context._compress_or_truncate"
+        ) as mock_compress:
+            result, removed, compressed = _trim_source_context(
+                prompt, current_tokens, budget, project_root=tmp_path
+            )
+
+        # Compression must NEVER be attempted for source code.
+        mock_compress.assert_not_called()
+        assert big_py_content not in result
+        assert compressed == []
+        assert "src/big.py" in removed
+
+    def test_markdown_dropped_when_compression_no_op(self, tmp_path: Path) -> None:
+        """If compression doesn't actually shrink, the file is dropped."""
+        big_md = "z" * 4000
+        prompt = _make_md_prompt(
+            [
+                ("src/keep.md", "a" * 200),
+                ("docs/noop.md", big_md),
+            ]
+        )
+        current_tokens = len(prompt) // 4
+        budget = current_tokens - 500
+
+        # Mock returns content of equal size → no real shrinkage.
+        with self._patch_compress(big_md):
+            result, removed, compressed = _trim_source_context(
+                prompt, current_tokens, budget, project_root=tmp_path
+            )
+
+        assert compressed == []
+        assert "docs/noop.md" in removed
+        assert big_md not in result
+
+    def test_tiny_markdown_skips_compression(self, tmp_path: Path) -> None:
+        """Files under MIN_COMPRESSIBLE_TOKENS bypass compression entirely."""
+        tiny_md = "tiny"  # << 500 tokens
+        prompt = _make_md_prompt(
+            [
+                ("src/keep.md", "a" * 200),
+                ("docs/tiny.md", tiny_md),
+            ]
+        )
+        current_tokens = len(prompt) // 4
+        budget = current_tokens - 50  # force trim of tiny.md
+
+        with patch(
+            "bmad_assist.compiler.strategic_context._compress_or_truncate"
+        ) as mock_compress:
+            _result, removed, compressed = _trim_source_context(
+                prompt, current_tokens, budget, project_root=tmp_path
+            )
+
+        # Tiny → don't even try compressing → drop straight away.
+        mock_compress.assert_not_called()
+        assert "docs/tiny.md" in removed
+        assert compressed == []
+
+    def test_compression_disabled_without_project_root(self) -> None:
+        """When project_root=None, markdown files fall through to drop."""
+        big_md = "x" * 4000
+        prompt = _make_md_prompt(
+            [
+                ("src/keep.md", "a" * 200),
+                ("docs/big.md", big_md),
+            ]
+        )
+        current_tokens = len(prompt) // 4
+        budget = current_tokens - 500
+
+        with patch(
+            "bmad_assist.compiler.strategic_context._compress_or_truncate"
+        ) as mock_compress:
+            _result, removed, compressed = _trim_source_context(
+                prompt, current_tokens, budget, project_root=None
+            )
+
+        # No project_root → no compression attempt → drop fallback.
+        mock_compress.assert_not_called()
+        assert "docs/big.md" in removed
+        assert compressed == []
+
+    def test_mixed_compresses_md_and_drops_source(self, tmp_path: Path) -> None:
+        """Mixed prompt: markdown compressed, source code dropped."""
+        big_md = "m" * 4000
+        big_py = "p" * 4000
+        prompt = _make_md_prompt(
+            [
+                ("src/keep.py", "a" * 200),
+                ("docs/info.md", big_md),
+                ("src/big.py", big_py),  # last → trimmed first
+            ]
+        )
+        current_tokens = len(prompt) // 4
+        # Budget tight enough to force trimming both lower-priority files.
+        budget = current_tokens - 1500
+
+        compressed_payload = "summary of info.md"
+        with self._patch_compress(compressed_payload):
+            result, removed, compressed = _trim_source_context(
+                prompt, current_tokens, budget, project_root=tmp_path
+            )
+
+        # big.py is dropped (last → first to go).
+        assert "src/big.py" in removed
+        assert big_py not in result
+        # info.md is compressed in place.
+        assert "docs/info.md" in compressed
+        assert compressed_payload in result
+        assert big_md not in result
+
+    def test_compression_failure_falls_back_to_drop(self, tmp_path: Path) -> None:
+        """If _compress_or_truncate raises, the file is dropped silently."""
+        big_md = "x" * 4000
+        prompt = _make_md_prompt(
+            [
+                ("src/keep.md", "a" * 200),
+                ("docs/broken.md", big_md),
+            ]
+        )
+        current_tokens = len(prompt) // 4
+        budget = current_tokens - 500
+
+        with patch(
+            "bmad_assist.compiler.strategic_context._compress_or_truncate",
+            side_effect=RuntimeError("LLM unavailable"),
+        ):
+            _result, removed, compressed = _trim_source_context(
+                prompt, current_tokens, budget, project_root=tmp_path
+            )
+
+        assert "docs/broken.md" in removed
+        assert compressed == []
+
+    def test_compression_logs_indicate_compression(
+        self, tmp_path: Path, caplog
+    ) -> None:
+        """Compression path emits its own info log distinct from drop."""
+        big_md = "x" * 4000
+        prompt = _make_md_prompt(
+            [
+                ("src/keep.md", "a" * 200),
+                ("docs/big.md", big_md),
+            ]
+        )
+        current_tokens = len(prompt) // 4
+        budget = current_tokens - 500
+
+        with self._patch_compress("smaller"), caplog.at_level(logging.INFO):
+            _trim_source_context(
+                prompt, current_tokens, budget, project_root=tmp_path
+            )
+
+        assert "Budget compress" in caplog.text
+        assert "docs/big.md" in caplog.text
+        # Summary line should report 1 compressed.
+        assert "compressed 1" in caplog.text
+
+    def test_mdx_and_markdown_extensions_recognized(self, tmp_path: Path) -> None:
+        """Compression covers .md, .markdown, and .mdx extensions."""
+        big = "x" * 4000
+        prompt = _make_md_prompt(
+            [
+                ("a.md", big),
+                ("b.markdown", big),
+                ("c.mdx", big),
+            ]
+        )
+        current_tokens = len(prompt) // 4
+        # Force EVERY file to be considered for trim.
+        budget = max(current_tokens // 5, 1)
+
+        with self._patch_compress("tiny"):
+            _result, removed, compressed = _trim_source_context(
+                prompt, current_tokens, budget, project_root=tmp_path
+            )
+
+        # All three extensions must be on the compressed path, not removed.
+        assert "a.md" in compressed
+        assert "b.markdown" in compressed
+        assert "c.mdx" in compressed
+        assert removed == []

--- a/tests/core/test_prompt_budget_trimming.py
+++ b/tests/core/test_prompt_budget_trimming.py
@@ -1,0 +1,93 @@
+"""Tests for post-compilation prompt budget trimming (Fix #3 and #6)."""
+
+import logging
+
+from bmad_assist.core.loop.handlers.base import _trim_source_context
+
+
+def _make_prompt(file_count: int, content_size: int = 1000) -> str:
+    """Build a fake compiled prompt XML with file blocks.
+
+    Files are named file_1.py through file_N.py (highest priority first).
+    """
+    files = []
+    for i in range(1, file_count + 1):
+        content = "x" * content_size
+        files.append(
+            f'<file id="f{i}" path="src/file_{i}.py" label="file_{i}">'
+            f"<![CDATA[{content}]]></file>"
+        )
+    context = "<context>\n" + "\n".join(files) + "\n</context>"
+    return (
+        f"<compiled-workflow>\n<mission>Do something</mission>\n"
+        f"{context}\n</compiled-workflow>"
+    )
+
+
+class TestTrimSourceContext:
+    """Test _trim_source_context budget enforcement."""
+
+    def test_no_trimming_when_within_budget(self) -> None:
+        """Prompt within budget returned unchanged."""
+        prompt = _make_prompt(3, content_size=100)
+        current_tokens = len(prompt) // 4
+        budget = current_tokens + 1000  # Well within budget
+        result = _trim_source_context(prompt, current_tokens, budget)
+        assert result == prompt
+
+    def test_trims_last_file_when_over_budget(self) -> None:
+        """Slightly over budget removes last (lowest priority) file."""
+        prompt = _make_prompt(3, content_size=2000)
+        current_tokens = len(prompt) // 4
+        # Set budget to be less than current but achievable by removing 1 file
+        budget = current_tokens - 400  # ~2000/4 = 500 tokens per file
+        result = _trim_source_context(prompt, current_tokens, budget)
+        assert "file_3.py" not in result
+        assert "file_1.py" in result
+        assert "file_2.py" in result
+
+    def test_trims_multiple_files_when_significantly_over(self) -> None:
+        """Significantly over budget removes multiple lowest-priority files."""
+        prompt = _make_prompt(5, content_size=2000)
+        current_tokens = len(prompt) // 4
+        # Budget achievable only by removing 3+ files
+        budget = current_tokens - 1200
+        result = _trim_source_context(prompt, current_tokens, budget)
+        # file_1 should always survive (highest priority)
+        assert "file_1.py" in result
+        # At least one file was removed
+        assert len(result) < len(prompt)
+
+    def test_preserves_non_source_content(self) -> None:
+        """Strategic context and mission are never trimmed."""
+        prompt = _make_prompt(3, content_size=2000)
+        current_tokens = len(prompt) // 4
+        budget = current_tokens - 800
+        result = _trim_source_context(prompt, current_tokens, budget)
+        assert "<mission>Do something</mission>" in result
+        assert "<compiled-workflow>" in result
+
+    def test_no_crash_on_missing_context(self) -> None:
+        """Prompt without any <file> blocks returns unchanged."""
+        prompt = "<compiled-workflow><mission>test</mission></compiled-workflow>"
+        result = _trim_source_context(prompt, 100, 50)
+        assert result == prompt
+
+    def test_logs_removed_files(self, caplog) -> None:
+        """Each removed file is logged."""
+        prompt = _make_prompt(3, content_size=2000)
+        current_tokens = len(prompt) // 4
+        budget = current_tokens - 800
+        with caplog.at_level(logging.INFO):
+            _trim_source_context(prompt, current_tokens, budget)
+        assert "Budget trim: removed source file" in caplog.text
+        assert "Trimmed" in caplog.text
+
+    def test_trim_result_estimates_lower_tokens(self) -> None:
+        """After trimming, len(result)//4 should be closer to budget."""
+        prompt = _make_prompt(4, content_size=4000)
+        current_tokens = len(prompt) // 4
+        budget = current_tokens // 2
+        result = _trim_source_context(prompt, current_tokens, budget)
+        new_tokens = len(result) // 4
+        assert new_tokens < current_tokens

--- a/tests/core/test_retry.py
+++ b/tests/core/test_retry.py
@@ -1,0 +1,252 @@
+"""Tests for invoke_with_timeout_retry retry mechanics and fallback timeout."""
+
+import pytest
+
+from bmad_assist.core.exceptions import ProviderTimeoutError
+from bmad_assist.core.retry import invoke_with_timeout_retry
+
+
+class TestRetryBasicBehavior:
+    """Test basic retry mechanics."""
+
+    def test_no_retry_when_none(self) -> None:
+        """timeout_retries=None raises immediately on timeout."""
+
+        def fail(**kw):
+            raise ProviderTimeoutError("timeout")
+
+        with pytest.raises(ProviderTimeoutError):
+            invoke_with_timeout_retry(fail, timeout_retries=None, phase_name="test")
+
+    def test_success_on_first_try(self) -> None:
+        """Successful invocation returns result directly."""
+
+        def succeed(**kw):
+            return "ok"
+
+        result = invoke_with_timeout_retry(
+            succeed, timeout_retries=2, phase_name="test"
+        )
+        assert result == "ok"
+
+    def test_retry_once_then_succeed(self) -> None:
+        """Primary fails once, succeeds on retry."""
+        call_count = 0
+
+        def flaky(**kw):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise ProviderTimeoutError("timeout")
+            return "recovered"
+
+        result = invoke_with_timeout_retry(
+            flaky, timeout_retries=2, phase_name="test"
+        )
+        assert result == "recovered"
+        assert call_count == 2
+
+    def test_retry_exhausted_raises(self) -> None:
+        """After N retries with no fallback, raises ProviderTimeoutError."""
+
+        def always_fail(**kw):
+            raise ProviderTimeoutError("timeout")
+
+        with pytest.raises(ProviderTimeoutError):
+            invoke_with_timeout_retry(
+                always_fail, timeout_retries=2, phase_name="test"
+            )
+
+    def test_retry_exhausted_calls_fallback(self) -> None:
+        """Primary fails N times, fallback is invoked."""
+
+        def primary_fail(**kw):
+            raise ProviderTimeoutError("primary timeout")
+
+        def fallback_succeed(**kw):
+            return "fallback_ok"
+
+        result = invoke_with_timeout_retry(
+            primary_fail,
+            timeout_retries=1,
+            phase_name="test",
+            fallback_invoke_fn=fallback_succeed,
+        )
+        assert result == "fallback_ok"
+
+    def test_kwargs_passed_to_invoke_fn(self) -> None:
+        """Verify kwargs flow to invoke function."""
+        received = {}
+
+        def capture(**kw):
+            received.update(kw)
+            return "ok"
+
+        invoke_with_timeout_retry(
+            capture,
+            timeout_retries=1,
+            phase_name="test",
+            prompt="hello",
+            timeout=600,
+            model="opus",
+        )
+        assert received["prompt"] == "hello"
+        assert received["timeout"] == 600
+        assert received["model"] == "opus"
+
+
+class TestFallbackTimeout:
+    """Test fallback timeout override (Fix #1)."""
+
+    def test_fallback_uses_explicit_timeout(self) -> None:
+        """When fallback_timeout=900, fallback receives timeout=900."""
+        received_timeout = None
+
+        def primary_fail(**kw):
+            raise ProviderTimeoutError("primary timeout")
+
+        def fallback_capture(**kw):
+            nonlocal received_timeout
+            received_timeout = kw.get("timeout")
+            return "ok"
+
+        invoke_with_timeout_retry(
+            primary_fail,
+            timeout_retries=1,
+            phase_name="test",
+            fallback_invoke_fn=fallback_capture,
+            fallback_timeout=900,
+            timeout=600,
+        )
+        assert received_timeout == 900
+
+    def test_fallback_uses_1_5x_multiplier_when_no_explicit(self) -> None:
+        """Without explicit fallback_timeout, uses 1.5x primary timeout."""
+        received_timeout = None
+
+        def primary_fail(**kw):
+            raise ProviderTimeoutError("primary timeout")
+
+        def fallback_capture(**kw):
+            nonlocal received_timeout
+            received_timeout = kw.get("timeout")
+            return "ok"
+
+        invoke_with_timeout_retry(
+            primary_fail,
+            timeout_retries=1,
+            phase_name="test",
+            fallback_invoke_fn=fallback_capture,
+            timeout=600,
+        )
+        assert received_timeout == 900  # 600 * 1.5
+
+    def test_fallback_multiplier_with_different_timeout(self) -> None:
+        """1.5x multiplier works with various base timeouts."""
+        received_timeout = None
+
+        def primary_fail(**kw):
+            raise ProviderTimeoutError("primary timeout")
+
+        def fallback_capture(**kw):
+            nonlocal received_timeout
+            received_timeout = kw.get("timeout")
+            return "ok"
+
+        invoke_with_timeout_retry(
+            primary_fail,
+            timeout_retries=1,
+            phase_name="test",
+            fallback_invoke_fn=fallback_capture,
+            timeout=1000,
+        )
+        assert received_timeout == 1500  # 1000 * 1.5
+
+    def test_fallback_default_timeout_when_no_timeout_in_kwargs(self) -> None:
+        """When no timeout in kwargs, fallback gets int(3600 * 1.5) = 5400."""
+        received_timeout = None
+
+        def primary_fail(**kw):
+            raise ProviderTimeoutError("primary timeout")
+
+        def fallback_capture(**kw):
+            nonlocal received_timeout
+            received_timeout = kw.get("timeout")
+            return "ok"
+
+        invoke_with_timeout_retry(
+            primary_fail,
+            timeout_retries=1,
+            phase_name="test",
+            fallback_invoke_fn=fallback_capture,
+        )
+        assert received_timeout == 5400  # 3600 * 1.5
+
+    def test_primary_timeout_unchanged(self) -> None:
+        """Primary always uses original timeout, not fallback timeout."""
+        primary_timeouts = []
+        call_count = 0
+
+        def primary_track(**kw):
+            nonlocal call_count
+            call_count += 1
+            primary_timeouts.append(kw.get("timeout"))
+            if call_count <= 2:
+                raise ProviderTimeoutError("timeout")
+            return "ok"
+
+        invoke_with_timeout_retry(
+            primary_track,
+            timeout_retries=3,
+            phase_name="test",
+            fallback_timeout=9999,
+            timeout=600,
+        )
+        # All primary attempts should use 600
+        assert all(t == 600 for t in primary_timeouts)
+
+    def test_fallback_kwargs_are_independent_copy(self) -> None:
+        """Verify original kwargs dict is not mutated by fallback."""
+        original_kwargs = {"timeout": 600, "prompt": "test"}
+
+        def primary_fail(**kw):
+            raise ProviderTimeoutError("timeout")
+
+        def fallback_ok(**kw):
+            return "ok"
+
+        invoke_with_timeout_retry(
+            primary_fail,
+            timeout_retries=1,
+            phase_name="test",
+            fallback_invoke_fn=fallback_ok,
+            fallback_timeout=900,
+            **original_kwargs,
+        )
+        # Original dict should not be mutated
+        assert original_kwargs["timeout"] == 600
+
+    def test_fallback_timeout_retries_independent(self) -> None:
+        """Fallback uses its own retry count."""
+        fallback_calls = 0
+
+        def primary_fail(**kw):
+            raise ProviderTimeoutError("primary")
+
+        def fallback_track(**kw):
+            nonlocal fallback_calls
+            fallback_calls += 1
+            if fallback_calls < 3:
+                raise ProviderTimeoutError("fallback timeout")
+            return "ok"
+
+        result = invoke_with_timeout_retry(
+            primary_fail,
+            timeout_retries=1,
+            phase_name="test",
+            fallback_invoke_fn=fallback_track,
+            fallback_timeout_retries=3,
+            timeout=600,
+        )
+        assert result == "ok"
+        assert fallback_calls == 3

--- a/tests/git/test_committer.py
+++ b/tests/git/test_committer.py
@@ -1,0 +1,404 @@
+"""Tests for git auto-commit scoping (Task #21).
+
+Covers:
+- stage_all_changes accepts an explicit path list and uses
+  ``git add -- <paths>`` instead of ``git add -A``.
+- BMAD_GIT_STAGE_ALL escape hatch preserves legacy ``git add -A``.
+- Empty path list is a no-op (returns True without running git).
+- Large-commit warning fires above the configured threshold.
+- Threshold env var parsing (default, explicit, disabled, invalid).
+- auto_commit_phase passes the filtered list to stage_all_changes.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from bmad_assist.core.state import Phase
+from bmad_assist.git.committer import (
+    _DEFAULT_LARGE_COMMIT_THRESHOLD,
+    _get_large_commit_threshold,
+    _should_force_stage_all,
+    auto_commit_phase,
+    stage_all_changes,
+)
+
+# =============================================================================
+# stage_all_changes — path-scoped staging
+# =============================================================================
+
+
+class TestStageAllChangesScoped:
+    """stage_all_changes scopes to explicit paths when provided."""
+
+    def test_explicit_paths_uses_add_dash_dash(self, tmp_path: Path) -> None:
+        """When paths given, uses ``git add -- <paths>`` not ``git add -A``."""
+        with patch("bmad_assist.git.committer._run_git") as mock_run:
+            mock_run.return_value = (0, "", "")
+            ok = stage_all_changes(tmp_path, paths=["src/a.py", "src/b.py"])
+
+        assert ok is True
+        assert mock_run.call_count == 1
+        args, _kwargs = mock_run.call_args
+        git_args = args[0]
+        # Must use explicit paths with the -- separator.
+        assert git_args == ["add", "--", "src/a.py", "src/b.py"]
+
+    def test_paths_none_falls_back_to_add_all(self, tmp_path: Path) -> None:
+        """paths=None → legacy ``git add -A`` behavior."""
+        with patch("bmad_assist.git.committer._run_git") as mock_run:
+            mock_run.return_value = (0, "", "")
+            ok = stage_all_changes(tmp_path, paths=None)
+
+        assert ok is True
+        args, _ = mock_run.call_args
+        assert args[0] == ["add", "-A"]
+
+    def test_no_paths_arg_defaults_to_add_all(self, tmp_path: Path) -> None:
+        """No paths kwarg → legacy behavior (backward compat for callers)."""
+        with patch("bmad_assist.git.committer._run_git") as mock_run:
+            mock_run.return_value = (0, "", "")
+            ok = stage_all_changes(tmp_path)
+
+        assert ok is True
+        args, _ = mock_run.call_args
+        assert args[0] == ["add", "-A"]
+
+    def test_empty_path_list_is_noop(self, tmp_path: Path) -> None:
+        """Empty list → don't invoke git at all; return True."""
+        with patch("bmad_assist.git.committer._run_git") as mock_run:
+            ok = stage_all_changes(tmp_path, paths=[])
+
+        assert ok is True
+        mock_run.assert_not_called()
+
+    def test_escape_hatch_forces_add_all(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """BMAD_GIT_STAGE_ALL=1 → legacy ``git add -A`` even when paths given."""
+        monkeypatch.setenv("BMAD_GIT_STAGE_ALL", "1")
+        with patch("bmad_assist.git.committer._run_git") as mock_run:
+            mock_run.return_value = (0, "", "")
+            ok = stage_all_changes(tmp_path, paths=["only/a.py"])
+
+        assert ok is True
+        args, _ = mock_run.call_args
+        # Escape hatch takes precedence — ignores the supplied paths.
+        assert args[0] == ["add", "-A"]
+
+    def test_escape_hatch_non_unity_value_ignored(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Only ``"1"`` activates the escape hatch; other values ignored."""
+        monkeypatch.setenv("BMAD_GIT_STAGE_ALL", "true")
+        with patch("bmad_assist.git.committer._run_git") as mock_run:
+            mock_run.return_value = (0, "", "")
+            stage_all_changes(tmp_path, paths=["a.py"])
+
+        args, _ = mock_run.call_args
+        assert args[0] == ["add", "--", "a.py"]  # scoped (not forced all)
+
+    def test_git_failure_returns_false(self, tmp_path: Path) -> None:
+        """Non-zero git exit code → return False, no exception."""
+        with patch("bmad_assist.git.committer._run_git") as mock_run:
+            mock_run.return_value = (128, "", "fatal: pathspec 'bad' did not match")
+            ok = stage_all_changes(tmp_path, paths=["bad.py"])
+
+        assert ok is False
+
+    def test_paths_with_dash_prefix_safe_via_separator(
+        self, tmp_path: Path
+    ) -> None:
+        """``--`` separator protects against paths that start with ``-``.
+
+        Without the ``--``, a path like ``-rf`` would be parsed as a
+        git flag. Regression guard for that concern.
+        """
+        with patch("bmad_assist.git.committer._run_git") as mock_run:
+            mock_run.return_value = (0, "", "")
+            stage_all_changes(tmp_path, paths=["-rf", "weird-file.py"])
+
+        args, _ = mock_run.call_args
+        # ``--`` appears immediately after ``add`` so git treats
+        # everything after as paths.
+        assert args[0][0:2] == ["add", "--"]
+        assert "-rf" in args[0]
+
+
+# =============================================================================
+# Threshold helpers
+# =============================================================================
+
+
+class TestLargeCommitThreshold:
+    """_get_large_commit_threshold parses env var with safe fallbacks."""
+
+    def test_default_when_env_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Unset env var → module default threshold."""
+        monkeypatch.delenv("BMAD_GIT_WARN_LARGE_COMMITS_THRESHOLD", raising=False)
+        assert _get_large_commit_threshold() == _DEFAULT_LARGE_COMMIT_THRESHOLD
+
+    def test_explicit_value(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Numeric env var → used verbatim."""
+        monkeypatch.setenv("BMAD_GIT_WARN_LARGE_COMMITS_THRESHOLD", "25")
+        assert _get_large_commit_threshold() == 25
+
+    def test_zero_disables_warning(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """0 is a valid value and disables the warning."""
+        monkeypatch.setenv("BMAD_GIT_WARN_LARGE_COMMITS_THRESHOLD", "0")
+        assert _get_large_commit_threshold() == 0
+
+    def test_negative_clamped_to_zero(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Negative values are treated as 'disabled' (clamped to 0)."""
+        monkeypatch.setenv("BMAD_GIT_WARN_LARGE_COMMITS_THRESHOLD", "-5")
+        assert _get_large_commit_threshold() == 0
+
+    def test_invalid_value_falls_back_to_default(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Non-integer env var → log a warning and fall back to default."""
+        monkeypatch.setenv("BMAD_GIT_WARN_LARGE_COMMITS_THRESHOLD", "not-a-number")
+        with caplog.at_level(logging.WARNING, logger="bmad_assist.git.committer"):
+            result = _get_large_commit_threshold()
+        assert result == _DEFAULT_LARGE_COMMIT_THRESHOLD
+        assert "Invalid BMAD_GIT_WARN_LARGE_COMMITS_THRESHOLD" in caplog.text
+
+
+class TestShouldForceStageAll:
+    """Escape-hatch env var helper."""
+
+    def test_unset_returns_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Unset BMAD_GIT_STAGE_ALL → escape hatch inactive."""
+        monkeypatch.delenv("BMAD_GIT_STAGE_ALL", raising=False)
+        assert _should_force_stage_all() is False
+
+    def test_value_one_returns_true(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``BMAD_GIT_STAGE_ALL=1`` → escape hatch active."""
+        monkeypatch.setenv("BMAD_GIT_STAGE_ALL", "1")
+        assert _should_force_stage_all() is True
+
+    def test_other_values_return_false(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Only the literal ``"1"`` counts; ``true`` / ``yes`` / ``""`` don't."""
+        monkeypatch.setenv("BMAD_GIT_STAGE_ALL", "true")
+        assert _should_force_stage_all() is False
+        monkeypatch.setenv("BMAD_GIT_STAGE_ALL", "yes")
+        assert _should_force_stage_all() is False
+        monkeypatch.setenv("BMAD_GIT_STAGE_ALL", "")
+        assert _should_force_stage_all() is False
+
+
+# =============================================================================
+# auto_commit_phase integration
+# =============================================================================
+
+
+class TestAutoCommitPhaseScoping:
+    """auto_commit_phase routes the filtered list into stage_all_changes."""
+
+    @pytest.fixture(autouse=True)
+    def enable_git(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Simulate ``--git`` being on for all tests in this class."""
+        monkeypatch.setenv("BMAD_GIT_COMMIT", "1")
+        # Disable the real pre-commit fix layer; not under test here.
+        monkeypatch.setattr(
+            "bmad_assist.git.committer._run_precommit_fix",
+            lambda _p: None,
+        )
+
+    def test_stages_only_filtered_paths(self, tmp_path: Path) -> None:
+        """auto_commit_phase calls stage_all_changes with the filter output."""
+        filtered = ["src/main.py", "stories/11-1-foo.md"]
+
+        with (
+            patch(
+                "bmad_assist.git.committer.get_modified_files",
+                return_value=filtered,
+            ),
+            patch(
+                "bmad_assist.git.committer.check_for_deleted_story_files",
+                return_value=[],
+            ),
+            patch("bmad_assist.git.committer.stage_all_changes") as mock_stage,
+            patch(
+                "bmad_assist.git.committer.commit_changes",
+                return_value=True,
+            ),
+        ):
+            mock_stage.return_value = True
+            ok = auto_commit_phase(Phase.CREATE_STORY, "11.1", tmp_path)
+
+        assert ok is True
+        # stage_all_changes invoked twice: initial + post-lint-refresh.
+        assert mock_stage.call_count == 2
+        # Both calls pass paths= kwarg (not None).
+        for call in mock_stage.call_args_list:
+            assert "paths" in call.kwargs
+            assert call.kwargs["paths"] == filtered
+
+    def test_large_commit_warning_fires(
+        self,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """When filtered file count > threshold, emit a clear WARNING."""
+        monkeypatch.setenv("BMAD_GIT_WARN_LARGE_COMMITS_THRESHOLD", "5")
+        # 10 files > threshold 5
+        many_files = [f"src/f{i}.py" for i in range(10)]
+
+        with (
+            patch(
+                "bmad_assist.git.committer.get_modified_files",
+                return_value=many_files,
+            ),
+            patch(
+                "bmad_assist.git.committer.check_for_deleted_story_files",
+                return_value=[],
+            ),
+            patch(
+                "bmad_assist.git.committer.stage_all_changes",
+                return_value=True,
+            ),
+            patch(
+                "bmad_assist.git.committer.commit_changes",
+                return_value=True,
+            ),
+            caplog.at_level(logging.WARNING, logger="bmad_assist.git.committer"),
+        ):
+            auto_commit_phase(Phase.CREATE_STORY, "11.1", tmp_path)
+
+        warnings = [
+            r for r in caplog.records if r.levelname == "WARNING"
+        ]
+        assert any("Large auto-commit detected" in r.getMessage() for r in warnings)
+        # Warning includes file count and threshold.
+        msg = [
+            r.getMessage() for r in warnings
+            if "Large auto-commit" in r.getMessage()
+        ][0]
+        assert "10 files" in msg
+        assert "threshold 5" in msg
+        assert "BMAD_GIT_WARN_LARGE_COMMITS_THRESHOLD" in msg  # tells user how to tune
+
+    def test_large_commit_warning_suppressed_when_threshold_zero(
+        self,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Threshold=0 disables the warning entirely, even for 1000 files."""
+        monkeypatch.setenv("BMAD_GIT_WARN_LARGE_COMMITS_THRESHOLD", "0")
+        many_files = [f"src/f{i}.py" for i in range(1000)]
+
+        with (
+            patch(
+                "bmad_assist.git.committer.get_modified_files",
+                return_value=many_files,
+            ),
+            patch(
+                "bmad_assist.git.committer.check_for_deleted_story_files",
+                return_value=[],
+            ),
+            patch(
+                "bmad_assist.git.committer.stage_all_changes",
+                return_value=True,
+            ),
+            patch(
+                "bmad_assist.git.committer.commit_changes",
+                return_value=True,
+            ),
+            caplog.at_level(logging.WARNING, logger="bmad_assist.git.committer"),
+        ):
+            auto_commit_phase(Phase.CREATE_STORY, "11.1", tmp_path)
+
+        assert not any(
+            "Large auto-commit" in r.getMessage() for r in caplog.records
+        )
+
+    def test_warning_skipped_when_below_threshold(
+        self,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Typical small commits (< threshold) don't trigger the warning."""
+        monkeypatch.delenv(
+            "BMAD_GIT_WARN_LARGE_COMMITS_THRESHOLD", raising=False
+        )
+        few_files = ["stories/11-1-foo.md"]
+
+        with (
+            patch(
+                "bmad_assist.git.committer.get_modified_files",
+                return_value=few_files,
+            ),
+            patch(
+                "bmad_assist.git.committer.check_for_deleted_story_files",
+                return_value=[],
+            ),
+            patch(
+                "bmad_assist.git.committer.stage_all_changes",
+                return_value=True,
+            ),
+            patch(
+                "bmad_assist.git.committer.commit_changes",
+                return_value=True,
+            ),
+            caplog.at_level(logging.WARNING, logger="bmad_assist.git.committer"),
+        ):
+            auto_commit_phase(Phase.CREATE_STORY, "11.1", tmp_path)
+
+        assert not any(
+            "Large auto-commit" in r.getMessage() for r in caplog.records
+        )
+
+    def test_refreshed_file_list_used_on_restage(
+        self, tmp_path: Path
+    ) -> None:
+        """After lint fixes, re-query get_modified_files and stage refreshed list.
+
+        Lint may modify files outside the original filter (e.g. auto-
+        generated caches). The refreshed list keeps staging aligned
+        with the current working tree state post-lint.
+        """
+        initial = ["src/a.py"]
+        refreshed = ["src/a.py", "src/b.py"]  # lint touched an extra file
+
+        with (
+            patch(
+                "bmad_assist.git.committer.get_modified_files",
+                side_effect=[initial, refreshed],
+            ),
+            patch(
+                "bmad_assist.git.committer.check_for_deleted_story_files",
+                return_value=[],
+            ),
+            patch("bmad_assist.git.committer.stage_all_changes") as mock_stage,
+            patch(
+                "bmad_assist.git.committer.commit_changes",
+                return_value=True,
+            ),
+        ):
+            mock_stage.return_value = True
+            auto_commit_phase(Phase.CREATE_STORY, "11.1", tmp_path)
+
+        # Two stage calls: first with initial, second with refreshed.
+        assert mock_stage.call_count == 2
+        assert mock_stage.call_args_list[0].kwargs["paths"] == initial
+        assert mock_stage.call_args_list[1].kwargs["paths"] == refreshed

--- a/tests/git/test_committer.py
+++ b/tests/git/test_committer.py
@@ -402,3 +402,157 @@ class TestAutoCommitPhaseScoping:
         assert mock_stage.call_count == 2
         assert mock_stage.call_args_list[0].kwargs["paths"] == initial
         assert mock_stage.call_args_list[1].kwargs["paths"] == refreshed
+
+
+# =============================================================================
+# Porcelain -z parsing (Task #22: running.lock fix)
+# =============================================================================
+#
+# get_modified_files used line[3:] which assumed the documented
+# "XY filename" format (3-char prefix). But git porcelain v1 without -z
+# emits 2-char prefix "M filename" in some staged states, which made
+# line[3:] eat the first char of the filename. Resulting in:
+#   ".bmad-assist/running.lock" → "bmad-assist/running.lock"
+# which then caused "git add -- <path>" to fail with "pathspec did not
+# match any files". Fix: use --porcelain=v1 -z which guarantees a
+# stable 2-char XY + space + path + NUL layout.
+
+
+from bmad_assist.git.committer import (  # noqa: E402
+    _parse_porcelain_z,
+    get_modified_files,
+)
+
+
+class TestParsePorcelainZ:
+    """_parse_porcelain_z handles the stable -z format across git quirks."""
+
+    def test_standard_modified_records(self) -> None:
+        """Plain space-M (unstaged modified) records parse cleanly."""
+        stdout = " M .bmad-assist/state.yaml\x00 M packages/y3a-client\x00"
+        records = _parse_porcelain_z(stdout)
+        assert records == [
+            (" M", ".bmad-assist/state.yaml"),
+            (" M", "packages/y3a-client"),
+        ]
+
+    def test_staged_only_record(self) -> None:
+        """Staged modified with worktree unchanged: X='M', Y=' '.
+
+        Regression guard for the original bug: text porcelain could
+        emit "M filename" (collapsed trailing-space Y) but -z is
+        always "M  filename" (2-char XY + separator space).
+        """
+        stdout = "M  .bmad-assist/running.lock\x00"
+        records = _parse_porcelain_z(stdout)
+        assert records == [("M ", ".bmad-assist/running.lock")]
+
+    def test_untracked_record(self) -> None:
+        """Untracked files use ``??`` status."""
+        stdout = "?? .bmad-assist/prompts/new.md\x00"
+        records = _parse_porcelain_z(stdout)
+        assert records == [("??", ".bmad-assist/prompts/new.md")]
+
+    def test_rename_consumes_two_records(self) -> None:
+        """Rename/copy emit TWO NUL-separated entries: new then old."""
+        # Rename: R  new.md\x00old.md\x00
+        stdout = "R  packages/new.md\x00packages/old.md\x00"
+        records = _parse_porcelain_z(stdout)
+        # We keep the NEW path only (post-rename name).
+        assert records == [("R ", "packages/new.md")]
+
+    def test_copy_consumes_two_records(self) -> None:
+        """Copy (C status) follows the same rename format."""
+        stdout = "C  packages/copy.md\x00packages/orig.md\x00"
+        records = _parse_porcelain_z(stdout)
+        assert records == [("C ", "packages/copy.md")]
+
+    def test_multiple_mixed_records(self) -> None:
+        """Modified + untracked + rename in one call."""
+        stdout = (
+            " M src/a.py\x00"
+            "?? src/b.py\x00"
+            "R  src/new.py\x00src/old.py\x00"
+            " D src/gone.py\x00"
+        )
+        records = _parse_porcelain_z(stdout)
+        assert records == [
+            (" M", "src/a.py"),
+            ("??", "src/b.py"),
+            ("R ", "src/new.py"),
+            (" D", "src/gone.py"),
+        ]
+
+    def test_empty_stdout_returns_empty_list(self) -> None:
+        """No output → no records."""
+        assert _parse_porcelain_z("") == []
+
+    def test_path_with_dot_prefix_preserved(self) -> None:
+        """Dotfile paths keep their leading dot (THE original bug)."""
+        stdout = "M  .bmad-assist/running.lock\x00 M .bmad-assist/state.yaml\x00"
+        records = _parse_porcelain_z(stdout)
+        paths = [p for _, p in records]
+        assert ".bmad-assist/running.lock" in paths
+        assert ".bmad-assist/state.yaml" in paths
+        # Neither entry should have lost its dot.
+        assert "bmad-assist/running.lock" not in paths
+
+
+class TestGetModifiedFilesExclusions:
+    """get_modified_files filters out bmad-assist runtime state files."""
+
+    def test_excludes_running_lock(self) -> None:
+        """``.bmad-assist/running.lock`` is bmad-assist's own lock; exclude it."""
+        stdout = (
+            "M  .bmad-assist/running.lock\x00"
+            " M src/real_change.py\x00"
+        )
+        with patch("bmad_assist.git.committer._run_git") as mock_run:
+            mock_run.return_value = (0, stdout, "")
+            files = get_modified_files(Path("/fake"))
+        assert ".bmad-assist/running.lock" not in files
+        assert "src/real_change.py" in files
+
+    def test_excludes_runs_directory(self) -> None:
+        """``.bmad-assist/runs/*`` are per-run logs; never auto-commit."""
+        stdout = (
+            " M .bmad-assist/runs/run-20260417T142447Z-09a886bd.yaml\x00"
+            " M src/real.py\x00"
+        )
+        with patch("bmad_assist.git.committer._run_git") as mock_run:
+            mock_run.return_value = (0, stdout, "")
+            files = get_modified_files(Path("/fake"))
+        assert all(not f.startswith(".bmad-assist/runs/") for f in files)
+        assert "src/real.py" in files
+
+    def test_excludes_prompts_cache_debug_output(self) -> None:
+        """Existing exclusions still work with the -z parser."""
+        stdout = (
+            "?? .bmad-assist/prompts/x.md\x00"
+            "?? .bmad-assist/cache/y.json\x00"
+            "?? .bmad-assist/debug/z.log\x00"
+            "?? _bmad-output/w.md\x00"
+            " M src/real.py\x00"
+        )
+        with patch("bmad_assist.git.committer._run_git") as mock_run:
+            mock_run.return_value = (0, stdout, "")
+            files = get_modified_files(Path("/fake"))
+        assert files == ["src/real.py"]
+
+    def test_legitimate_state_yaml_kept(self) -> None:
+        """``.bmad-assist/state.yaml`` stays in the commit (resume-after-crash)."""
+        stdout = " M .bmad-assist/state.yaml\x00"
+        with patch("bmad_assist.git.committer._run_git") as mock_run:
+            mock_run.return_value = (0, stdout, "")
+            files = get_modified_files(Path("/fake"))
+        assert files == [".bmad-assist/state.yaml"]
+
+    def test_regression_path_integrity(self) -> None:
+        """Leading dots survive parsing (the original failure mode)."""
+        # Reproduces the exact broken input:
+        # previously this got parsed as "bmad-assist/running.lock" (no dot).
+        stdout = "M  .bmad-assist/state.yaml\x00"
+        with patch("bmad_assist.git.committer._run_git") as mock_run:
+            mock_run.return_value = (0, stdout, "")
+            files = get_modified_files(Path("/fake"))
+        assert files == [".bmad-assist/state.yaml"]

--- a/tests/git/test_diff.py
+++ b/tests/git/test_diff.py
@@ -369,3 +369,146 @@ class TestGarbagePatternsIncludeBmadPaths:
         result = validate_diff_quality(diff_content)
         assert result.garbage_files == 1
         assert result.source_files == 1
+
+
+# =============================================================================
+# Configurable Garbage Patterns (Fix #4)
+# =============================================================================
+#
+# validate_diff_quality() must accept user-configurable extra patterns and
+# whitelist exclusions so users can control which files count as garbage.
+
+
+class TestConfigurableGarbagePatterns:
+    """User-supplied garbage patterns and exclude paths."""
+
+    def test_exclude_paths_whitelist_default_garbage(self) -> None:
+        """An exclude_paths entry must override default garbage classification.
+
+        The original report: ``.opencode/package-lock.json`` is a tracked
+        file in the user's repo but matches the default ``package-lock.json$``
+        pattern. With it whitelisted, it should count as a source file.
+        """
+        diff_content = (
+            " .opencode/package-lock.json | 200 +++++++++++++++++\n"
+            " src/main.py | 5 +-\n"
+            " 2 files changed\n"
+        )
+        result = validate_diff_quality(
+            diff_content,
+            exclude_paths=[".opencode/package-lock.json"],
+        )
+        assert result.garbage_files == 0
+        assert result.source_files == 2
+        assert result.is_valid is True
+
+    def test_exclude_paths_glob_pattern(self) -> None:
+        """exclude_paths supports fnmatch glob patterns."""
+        diff_content = (
+            " vendor/foo.lock | 10 +\n"
+            " vendor/bar.lock | 5 +\n"
+            " src/main.py | 1 +\n"
+        )
+        result = validate_diff_quality(
+            diff_content,
+            exclude_paths=["vendor/*.lock"],
+        )
+        assert result.garbage_files == 0
+        assert result.source_files == 3
+
+    def test_exclude_paths_basename_match(self) -> None:
+        """Bare basenames in exclude_paths should match by suffix."""
+        diff_content = (
+            " a/b/c/special.lock | 3 +\n"
+            " src/main.py | 1 +\n"
+        )
+        # Bare "special.lock" without glob metachars should match by
+        # path.endswith("/special.lock").
+        result = validate_diff_quality(
+            diff_content,
+            exclude_paths=["special.lock"],
+        )
+        assert result.garbage_files == 0
+
+    def test_extra_garbage_patterns_appended(self) -> None:
+        """extra_garbage_patterns must be appended to the default list."""
+        diff_content = (
+            " src/generated/api.ts | 500 +++++\n"
+            " src/main.py | 5 +-\n"
+        )
+        # Without extra: api.ts is a source file
+        baseline = validate_diff_quality(diff_content)
+        assert baseline.garbage_files == 0
+        # With extra pattern: api.ts becomes garbage
+        with_extra = validate_diff_quality(
+            diff_content,
+            extra_garbage_patterns=[r"src/generated/"],
+        )
+        assert with_extra.garbage_files == 1
+        assert with_extra.source_files == 1
+
+    def test_exclude_takes_priority_over_extra_patterns(self) -> None:
+        """exclude_paths is a whitelist override over extra_garbage_patterns."""
+        diff_content = " src/generated/api.ts | 1 +\n src/main.py | 1 +\n"
+        result = validate_diff_quality(
+            diff_content,
+            extra_garbage_patterns=[r"src/generated/"],
+            exclude_paths=["src/generated/api.ts"],
+        )
+        # Exclude wins → counted as source.
+        assert result.garbage_files == 0
+        assert result.source_files == 2
+
+    def test_default_behavior_unchanged_without_overrides(self) -> None:
+        """No new params → behavior matches the legacy hardcoded list."""
+        diff_content = (
+            " .bmad-assist/state.yaml | 6 +-\n"
+            " package-lock.json | 100 +\n"
+            " src/main.py | 5 +-\n"
+        )
+        result = validate_diff_quality(diff_content)
+        assert result.garbage_files == 2
+        assert result.source_files == 1
+
+
+class TestGitConfigModel:
+    """GitConfig is wired through to the main Config and validates."""
+
+    def test_default_git_config_has_zero_overrides(self) -> None:
+        """Default GitConfig has empty exclude/extra lists and 0.3 ratio."""
+        from bmad_assist.core.config.models.features import GitConfig
+
+        cfg = GitConfig()
+        assert cfg.garbage_exclude_paths == ()
+        assert cfg.garbage_extra_patterns == ()
+        assert cfg.max_garbage_ratio == 0.3
+
+    def test_git_config_round_trip(self) -> None:
+        """Building from dict preserves provided values."""
+        from bmad_assist.core.config.models.features import GitConfig
+
+        cfg = GitConfig(
+            garbage_exclude_paths=(".opencode/package-lock.json",),
+            garbage_extra_patterns=(r"^vendor/",),
+            max_garbage_ratio=0.5,
+        )
+        assert ".opencode/package-lock.json" in cfg.garbage_exclude_paths
+        assert r"^vendor/" in cfg.garbage_extra_patterns
+        assert cfg.max_garbage_ratio == 0.5
+
+    def test_main_config_exposes_git_section(self) -> None:
+        """main.Config aggregates GitConfig under .git."""
+        from bmad_assist.core.config.models.features import GitConfig
+        from bmad_assist.core.config.models.main import Config
+        from bmad_assist.core.config.models.providers import (
+            MasterProviderConfig,
+            ProviderConfig,
+        )
+
+        config = Config(
+            providers=ProviderConfig(
+                master=MasterProviderConfig(provider="claude", model="opus")
+            )
+        )
+        assert isinstance(config.git, GitConfig)
+        assert config.git.max_garbage_ratio == 0.3

--- a/tests/providers/test_claude.py
+++ b/tests/providers/test_claude.py
@@ -530,7 +530,7 @@ class TestClaudeSubprocessProviderErrors:
     def test_invoke_timeout_error_includes_truncated_prompt(
         self, provider: ClaudeSubprocessProvider, accelerated_time
     ) -> None:
-        """Test AC8: Timeout error includes prompt (truncated if > 100 chars)."""
+        """Test AC8: Timeout error includes prompt_chars count, not content."""
         long_prompt = "x" * 150
 
         with patch("bmad_assist.providers.claude.Popen") as mock:
@@ -540,16 +540,15 @@ class TestClaudeSubprocessProviderErrors:
                 provider.invoke(long_prompt, timeout=1)
 
             error_msg = str(exc_info.value)
-            # Should be truncated
-            assert "x" * 100 in error_msg
-            assert "..." in error_msg
-            # Should NOT contain full prompt
-            assert "x" * 150 not in error_msg
+            # Should NOT contain prompt content (Fix #5)
+            assert "x" * 100 not in error_msg
+            # Should contain prompt char count
+            assert "prompt_chars=150" in error_msg
 
     def test_invoke_timeout_error_short_prompt_not_truncated(
         self, provider: ClaudeSubprocessProvider, accelerated_time
     ) -> None:
-        """Test AC8: Short prompts are not truncated in timeout error."""
+        """Test AC8: Short prompts also show char count, not content."""
         short_prompt = "Hello world"
 
         with patch("bmad_assist.providers.claude.Popen") as mock:
@@ -559,8 +558,8 @@ class TestClaudeSubprocessProviderErrors:
                 provider.invoke(short_prompt, timeout=1)
 
             error_msg = str(exc_info.value)
-            assert "Hello world" in error_msg
-            assert "..." not in error_msg
+            assert "Hello world" not in error_msg
+            assert "prompt_chars=11" in error_msg
 
     def test_invoke_timeout_kills_process(
         self, provider: ClaudeSubprocessProvider, accelerated_time

--- a/tests/providers/test_claude_sdk.py
+++ b/tests/providers/test_claude_sdk.py
@@ -820,3 +820,201 @@ class TestClaudeSDKIntegration:
 
         assert query is not None
         assert ClaudeAgentOptions is not None
+
+
+# =============================================================================
+# Model logging mismatch (Fix #2) and SDK stderr capture (Fix #3)
+# =============================================================================
+#
+# When invoking the claude SDK with display_model="glm-5.1" but underlying
+# model="opus" (e.g. via ~/.claude/glm.json settings file), the crash log
+# used to emit "model=opus" — confusing operators who configured glm-5.1.
+# After Fix #2, the log includes both display and SDK model when they
+# differ. Fix #3 also dumps captured CLI stderr to a per-run debug file.
+
+
+class TestSdkCrashLogIncludesDisplayModel:
+    """Crash warnings must surface the user-visible display model."""
+
+    @pytest.fixture
+    def provider(self) -> ClaudeSDKProvider:
+        return ClaudeSDKProvider()
+
+    def test_cli_crash_log_uses_display_model_when_different(
+        self, provider: ClaudeSDKProvider, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """When display_model differs from the SDK model, log both."""
+        import logging
+
+        # Simulate the bundled SDK raising the exact exception bmad-assist
+        # was getting in production: "Command failed with exit code 1".
+        async_mock = AsyncMock(side_effect=Exception("Command failed with exit code 1"))
+        with (
+            patch.object(provider, "_invoke_async", async_mock),
+            caplog.at_level(logging.WARNING, logger="bmad_assist.providers.claude_sdk"),
+        ):
+            with pytest.raises(ProviderTimeoutError):
+                provider.invoke("Hello", model="opus", display_model="glm-5.1")
+
+        # Crash warning must mention BOTH glm-5.1 (user-facing) and opus
+        # (sdk model bound under the hood) — operators searching their
+        # config for "glm-5.1" must find a hit.
+        crash_warnings = [
+            r for r in caplog.records if "SDK CLI crash" in r.getMessage()
+        ]
+        assert crash_warnings, "expected SDK CLI crash warning"
+        msg = crash_warnings[-1].getMessage()
+        assert "glm-5.1" in msg
+        assert "sdk_model=opus" in msg
+
+    def test_cli_crash_log_omits_sdk_model_when_same(
+        self, provider: ClaudeSDKProvider, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """No display_model override → log just the model, no sdk_model= suffix."""
+        import logging
+
+        async_mock = AsyncMock(side_effect=Exception("Command failed with exit code 1"))
+        with (
+            patch.object(provider, "_invoke_async", async_mock),
+            caplog.at_level(logging.WARNING, logger="bmad_assist.providers.claude_sdk"),
+        ):
+            with pytest.raises(ProviderTimeoutError):
+                provider.invoke("Hello", model="opus")  # no display_model
+
+        crash_warnings = [
+            r for r in caplog.records if "SDK CLI crash" in r.getMessage()
+        ]
+        assert crash_warnings
+        msg = crash_warnings[-1].getMessage()
+        assert "opus" in msg
+        # No display_model override → don't add sdk_model= noise.
+        assert "sdk_model=" not in msg
+
+
+class TestSdkStderrCaptureToDebugFile:
+    """SDK CLI stderr is dumped to a per-run debug file on crash."""
+
+    @pytest.fixture
+    def provider(self) -> ClaudeSDKProvider:
+        return ClaudeSDKProvider()
+
+    def test_dump_stderr_writes_debug_file_when_run_dir_exists(
+        self, provider: ClaudeSDKProvider, tmp_path: Path
+    ) -> None:
+        """When a run-scoped dir is active, _dump_stderr_debug_log writes a file."""
+        from bmad_assist.core import io as core_io
+
+        # Seed thread-local run dir
+        original = getattr(core_io._run_context, "prompts_dir", None)
+        try:
+            run_dir = tmp_path / "run-test"
+            core_io._run_context.prompts_dir = run_dir
+
+            provider._last_stderr_lines = [
+                "node:internal/process/promises:391\n",
+                "    triggerUncaughtException(err, true);\n",
+                "    ^\n",
+                "Error: ENOMEM: not enough memory\n",
+            ]
+            provider._dump_stderr_debug_log(
+                shown_model="glm-5.1",
+                effective_model="opus",
+                error="Command failed with exit code 1",
+            )
+
+            assert run_dir.exists()
+            dumps = list(run_dir.glob("sdk-stderr-*.log"))
+            assert len(dumps) == 1
+            content = dumps[0].read_text()
+            assert "display_model: glm-5.1" in content
+            assert "effective_model: opus" in content
+            assert "ENOMEM" in content
+            assert "stderr_lines_captured: 4" in content
+        finally:
+            if original is None:
+                if hasattr(core_io._run_context, "prompts_dir"):
+                    delattr(core_io._run_context, "prompts_dir")
+            else:
+                core_io._run_context.prompts_dir = original
+
+    def test_dump_stderr_no_run_dir_is_silent(
+        self, provider: ClaudeSDKProvider, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Outside a run (e.g. unit tests), no orphan files are written."""
+        from bmad_assist.core import io as core_io
+
+        original = getattr(core_io._run_context, "prompts_dir", None)
+        try:
+            if hasattr(core_io._run_context, "prompts_dir"):
+                delattr(core_io._run_context, "prompts_dir")
+
+            provider._last_stderr_lines = ["err\n"]
+            # Must not raise even with no run dir set.
+            provider._dump_stderr_debug_log(
+                shown_model="opus",
+                effective_model="opus",
+                error="boom",
+            )
+        finally:
+            if original is not None:
+                core_io._run_context.prompts_dir = original
+
+    def test_dump_stderr_swallows_write_errors(
+        self, provider: ClaudeSDKProvider, tmp_path: Path
+    ) -> None:
+        """Diagnostic dumping must never mask the original error."""
+        from bmad_assist.core import io as core_io
+
+        # Point run dir at a path that can't be created (file collision).
+        blocker = tmp_path / "blocked"
+        blocker.write_text("not a directory")
+
+        original = getattr(core_io._run_context, "prompts_dir", None)
+        try:
+            core_io._run_context.prompts_dir = blocker / "subdir"
+            provider._last_stderr_lines = ["err\n"]
+            # Must not raise even though mkdir/write will fail.
+            provider._dump_stderr_debug_log(
+                shown_model="opus",
+                effective_model="opus",
+                error="boom",
+            )
+        finally:
+            if original is None:
+                if hasattr(core_io._run_context, "prompts_dir"):
+                    delattr(core_io._run_context, "prompts_dir")
+            else:
+                core_io._run_context.prompts_dir = original
+
+
+class TestGetCurrentRunDir:
+    """Public accessor for the run-scoped prompts directory."""
+
+    def test_returns_none_when_no_run_active(self) -> None:
+        from bmad_assist.core import io as core_io
+        from bmad_assist.core.io import get_current_run_dir
+
+        original = getattr(core_io._run_context, "prompts_dir", None)
+        try:
+            if hasattr(core_io._run_context, "prompts_dir"):
+                delattr(core_io._run_context, "prompts_dir")
+            assert get_current_run_dir() is None
+        finally:
+            if original is not None:
+                core_io._run_context.prompts_dir = original
+
+    def test_returns_active_run_dir(self, tmp_path: Path) -> None:
+        from bmad_assist.core import io as core_io
+        from bmad_assist.core.io import get_current_run_dir
+
+        original = getattr(core_io._run_context, "prompts_dir", None)
+        try:
+            run_dir = tmp_path / "run-abc"
+            core_io._run_context.prompts_dir = run_dir
+            assert get_current_run_dir() == run_dir
+        finally:
+            if original is None:
+                if hasattr(core_io._run_context, "prompts_dir"):
+                    delattr(core_io._run_context, "prompts_dir")
+            else:
+                core_io._run_context.prompts_dir = original

--- a/tests/providers/test_opencode.py
+++ b/tests/providers/test_opencode.py
@@ -637,3 +637,204 @@ class TestDocstringsExist:
     def test_supports_model_has_docstring(self) -> None:
         """Test supports_model() has docstring."""
         assert OpenCodeProvider.supports_model.__doc__ is not None
+
+
+# =============================================================================
+# Output-idle watchdog (Task 12)
+# =============================================================================
+#
+# When the opencode CLI produces no bytes for idle_timeout seconds, the
+# wait loop must kill it early and raise ProviderTimeoutError with a
+# distinct "idle" message. Without this, a silently-stuck CLI wastes
+# the full hard timeout (observed: 30 minutes on zai-coding-plan/glm-5.1).
+
+import time as _time
+
+from bmad_assist.providers.opencode import (  # noqa: E402
+    _IDLE_POLL_INTERVAL_SECONDS,
+    _DEFAULT_IDLE_TIMEOUT_SECONDS,
+    _IdleTracker,
+    _resolve_idle_timeout,
+)
+
+
+class TestIdleTracker:
+    """_IdleTracker tracks last-activity timestamp for the watchdog."""
+
+    def test_fresh_tracker_has_near_zero_idle(self) -> None:
+        tracker = _IdleTracker()
+        # Small elapsed time between construction and reading is fine.
+        assert tracker.idle_for() < 0.5
+
+    def test_mark_resets_idle(self) -> None:
+        tracker = _IdleTracker()
+        _time.sleep(0.05)
+        assert tracker.idle_for() >= 0.04
+        tracker.mark()
+        assert tracker.idle_for() < 0.02
+
+    def test_idle_for_monotonic_increase(self) -> None:
+        tracker = _IdleTracker()
+        first = tracker.idle_for()
+        _time.sleep(0.02)
+        second = tracker.idle_for()
+        assert second >= first
+
+
+class TestResolveIdleTimeout:
+    """_resolve_idle_timeout honors env var."""
+
+    def test_default_when_env_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("BMAD_PROVIDER_IDLE_TIMEOUT", raising=False)
+        assert _resolve_idle_timeout() == _DEFAULT_IDLE_TIMEOUT_SECONDS
+
+    def test_explicit_value(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("BMAD_PROVIDER_IDLE_TIMEOUT", "42.5")
+        assert _resolve_idle_timeout() == 42.5
+
+    def test_zero_disables_watchdog(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("BMAD_PROVIDER_IDLE_TIMEOUT", "0")
+        assert _resolve_idle_timeout() == 0.0
+
+    def test_negative_clamped_to_zero(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("BMAD_PROVIDER_IDLE_TIMEOUT", "-5")
+        assert _resolve_idle_timeout() == 0.0
+
+    def test_invalid_value_falls_back_to_default(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        import logging as _logging
+
+        monkeypatch.setenv("BMAD_PROVIDER_IDLE_TIMEOUT", "not-a-number")
+        with caplog.at_level(_logging.WARNING, logger="bmad_assist.providers.opencode"):
+            result = _resolve_idle_timeout()
+        assert result == _DEFAULT_IDLE_TIMEOUT_SECONDS
+        assert "Invalid BMAD_PROVIDER_IDLE_TIMEOUT" in caplog.text
+
+
+class TestOpenCodeIdleWatchdog:
+    """Idle watchdog kills the subprocess on prolonged silence."""
+
+    @pytest.fixture
+    def provider(self) -> OpenCodeProvider:
+        return OpenCodeProvider()
+
+    def test_idle_timeout_fires_when_subprocess_silent(
+        self, provider: OpenCodeProvider, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Long timeout + silent subprocess → idle-timeout error, not hard."""
+        # Configure idle watchdog to fire almost immediately (0.05s) and
+        # set a long hard timeout so the idle branch wins the race.
+        monkeypatch.setenv("BMAD_PROVIDER_IDLE_TIMEOUT", "0.05")
+
+        # Mock perf_counter so the wait loop doesn't need real seconds
+        # to reach the hard limit — we only care that idle fires first.
+        call_count = [0]
+
+        def mock_perf_counter() -> float:
+            # Start at 0, advance by 0.01s per call → stays below the
+            # large hard timeout (100s) but above the idle threshold
+            # once the test sleeps briefly in between.
+            call_count[0] += 1
+            return call_count[0] * 0.01
+
+        with (
+            patch("bmad_assist.providers.opencode.Popen") as mock_popen,
+            patch(
+                "bmad_assist.providers.opencode.time.perf_counter",
+                side_effect=mock_perf_counter,
+            ),
+        ):
+            mock_popen.return_value = create_opencode_mock_process(
+                never_finish=True
+            )
+            # Hard timeout much larger than idle → idle must win.
+            with pytest.raises(ProviderTimeoutError) as exc_info:
+                # Sleep inside the mock wait call so real time advances
+                # past the 0.05s idle threshold before the loop first
+                # checks idle_for().
+                import bmad_assist.providers.opencode as _oc
+
+                original_wait = mock_popen.return_value.wait
+                def wait_with_sleep(timeout: float | None = None) -> int:
+                    _time.sleep(0.06)  # push real monotonic past idle limit
+                    return original_wait(timeout=timeout)
+                mock_popen.return_value.wait = wait_with_sleep
+                provider.invoke("Hello", timeout=100)
+
+            # Error message must identify this as idle timeout, not hard.
+            msg = str(exc_info.value)
+            assert "idle-timeout" in msg.lower() or "no output" in msg.lower()
+
+    def test_watchdog_disabled_via_env_uses_hard_timeout_only(
+        self, provider: OpenCodeProvider, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """BMAD_PROVIDER_IDLE_TIMEOUT=0 → legacy single-shot wait path."""
+        monkeypatch.setenv("BMAD_PROVIDER_IDLE_TIMEOUT", "0")
+
+        with patch("bmad_assist.providers.opencode.Popen") as mock_popen:
+            mock_popen.return_value = create_opencode_mock_process(
+                never_finish=True
+            )
+            with pytest.raises(ProviderTimeoutError) as exc_info:
+                provider.invoke("Hello", timeout=5)
+
+        msg = str(exc_info.value)
+        # Hard timeout message mentions "timeout after Xs", NOT idle.
+        assert "idle-timeout" not in msg.lower()
+        assert "no output" not in msg.lower()
+        assert "timeout after" in msg.lower()
+
+    def test_short_timeout_skips_polling_loop(
+        self, provider: OpenCodeProvider, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """timeout <= idle_timeout → legacy single-shot path, no polling overhead.
+
+        This regression guard ensures the existing 50 opencode tests
+        (which all use timeout < 10s) don't get slowed down by the
+        polling loop. The heuristic ``effective_timeout > idle_timeout``
+        keeps them on the single-wait path.
+        """
+        # Leave default idle_timeout (300s) in place, use a short timeout.
+        monkeypatch.delenv("BMAD_PROVIDER_IDLE_TIMEOUT", raising=False)
+
+        with patch("bmad_assist.providers.opencode.Popen") as mock_popen:
+            mock_popen.return_value = create_opencode_mock_process(
+                never_finish=True
+            )
+            start = _time.perf_counter()
+            with pytest.raises(ProviderTimeoutError):
+                provider.invoke("Hello", timeout=5)
+            elapsed = _time.perf_counter() - start
+
+        # Must finish quickly (single-shot path). If the polling loop
+        # kicked in, the test would either hang or take >= poll interval
+        # (5s). Assert < 2s as a generous safety margin.
+        assert elapsed < 2.0
+
+    def test_streaming_output_resets_idle(
+        self, provider: OpenCodeProvider, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A process that produces output throughout doesn't trigger idle.
+
+        Regression guard: ensure the idle watchdog doesn't misfire on
+        normal long-running calls that stream output continuously.
+        """
+        # Normal successful run shouldn't need idle handling at all.
+        monkeypatch.setenv("BMAD_PROVIDER_IDLE_TIMEOUT", "0.5")
+
+        with patch("bmad_assist.providers.opencode.Popen") as mock_popen:
+            mock_popen.return_value = create_opencode_mock_process(
+                response_text="Hello world from opencode",
+                returncode=0,
+            )
+            # Short timeout → legacy single-shot path, but the mock
+            # returns successfully so no timeout should fire anyway.
+            result = provider.invoke("Test", timeout=5)
+
+        assert result.exit_code == 0
+        assert "Hello world" in result.stdout

--- a/tests/providers/test_timeout.py
+++ b/tests/providers/test_timeout.py
@@ -352,7 +352,7 @@ class TestTimeoutContext:
     def test_prompt_truncation_long_prompt(
         self, provider: ClaudeSubprocessProvider, accelerated_time
     ) -> None:
-        """Test AC8: Prompt truncated to 100 chars in error message."""
+        """Test AC8: Error message contains prompt_chars count, not content."""
         long_prompt = "x" * 150
 
         with patch("bmad_assist.providers.claude.Popen") as mock_popen:
@@ -364,16 +364,15 @@ class TestTimeoutContext:
                 provider.invoke(long_prompt, timeout=5)
 
             error_msg = str(exc_info.value)
-            # Should be truncated
-            assert "x" * 100 in error_msg
-            assert "..." in error_msg
-            # Should NOT contain full prompt
-            assert "x" * 150 not in error_msg
+            # Should NOT contain prompt content (Fix #5)
+            assert "x" * 100 not in error_msg
+            # Should contain prompt char count instead
+            assert "prompt_chars=150" in error_msg
 
     def test_prompt_truncation_short_prompt(
         self, provider: ClaudeSubprocessProvider, accelerated_time
     ) -> None:
-        """Test AC8: Short prompts not truncated."""
+        """Test AC8: Short prompts also use char count, not content."""
         short_prompt = "Hello world"
 
         with patch("bmad_assist.providers.claude.Popen") as mock_popen:
@@ -385,9 +384,10 @@ class TestTimeoutContext:
                 provider.invoke(short_prompt, timeout=5)
 
             error_msg = str(exc_info.value)
-            assert "Hello world" in error_msg
-            # No truncation indicator for short prompts
-            # (only check if prompt is short - no "..." appended)
+            # Prompt content not in error message (Fix #5)
+            assert "Hello world" not in error_msg
+            # Char count is included
+            assert "prompt_chars=11" in error_msg
 
     def test_utf8_prompt_truncation_preserves_characters(
         self, provider: ClaudeSubprocessProvider, accelerated_time

--- a/tests/providers/test_timeout_prompt_leak.py
+++ b/tests/providers/test_timeout_prompt_leak.py
@@ -1,0 +1,94 @@
+"""Tests for timeout error prompt leak prevention (Fix #5)."""
+
+import logging
+from unittest.mock import patch
+
+import pytest
+
+from bmad_assist.core.exceptions import ProviderTimeoutError
+from bmad_assist.providers import ClaudeSubprocessProvider
+
+from .conftest import create_mock_process
+
+
+class TestTimeoutErrorNoPromptLeak:
+    """Verify timeout errors don't leak prompt content (Fix #5)."""
+
+    @pytest.fixture
+    def provider(self) -> ClaudeSubprocessProvider:
+        """Create provider instance."""
+        return ClaudeSubprocessProvider()
+
+    def test_timeout_error_does_not_contain_prompt(
+        self, provider: ClaudeSubprocessProvider, accelerated_time
+    ) -> None:
+        """Error message must not contain the prompt text."""
+        unique_prompt = "UNIQUE_SECRET_PROMPT_CONTENT_xyz123"
+
+        with patch("bmad_assist.providers.claude.Popen") as mock_popen:
+            mock_popen.return_value = create_mock_process(never_finish=True)
+
+            with pytest.raises(ProviderTimeoutError) as exc_info:
+                provider.invoke(unique_prompt, timeout=5)
+
+        error_msg = str(exc_info.value)
+        assert unique_prompt not in error_msg
+
+    def test_timeout_error_contains_timeout_value(
+        self, provider: ClaudeSubprocessProvider, accelerated_time
+    ) -> None:
+        """Error message should include the timeout duration."""
+        with patch("bmad_assist.providers.claude.Popen") as mock_popen:
+            mock_popen.return_value = create_mock_process(never_finish=True)
+
+            with pytest.raises(ProviderTimeoutError) as exc_info:
+                provider.invoke("test prompt", timeout=5)
+
+        error_msg = str(exc_info.value)
+        assert "5s" in error_msg
+
+    def test_timeout_error_contains_model_info(
+        self, provider: ClaudeSubprocessProvider, accelerated_time
+    ) -> None:
+        """Error message should include model info."""
+        with patch("bmad_assist.providers.claude.Popen") as mock_popen:
+            mock_popen.return_value = create_mock_process(never_finish=True)
+
+            with pytest.raises(ProviderTimeoutError) as exc_info:
+                provider.invoke("test prompt", timeout=5, model="opus")
+
+        error_msg = str(exc_info.value)
+        assert "model=" in error_msg
+
+    def test_timeout_error_contains_prompt_char_count(
+        self, provider: ClaudeSubprocessProvider, accelerated_time
+    ) -> None:
+        """Error message should include prompt length instead of content."""
+        prompt = "x" * 5000
+
+        with patch("bmad_assist.providers.claude.Popen") as mock_popen:
+            mock_popen.return_value = create_mock_process(never_finish=True)
+
+            with pytest.raises(ProviderTimeoutError) as exc_info:
+                provider.invoke(prompt, timeout=5)
+
+        error_msg = str(exc_info.value)
+        assert "prompt_chars=5000" in error_msg
+
+    def test_prompt_logged_at_provider_level(
+        self, provider: ClaudeSubprocessProvider, accelerated_time, caplog
+    ) -> None:
+        """Truncated prompt IS logged as WARNING at provider level."""
+        prompt = "a" * 200
+
+        with patch("bmad_assist.providers.claude.Popen") as mock_popen:
+            mock_popen.return_value = create_mock_process(never_finish=True)
+
+            with (
+                caplog.at_level(logging.WARNING, logger="bmad_assist.providers.claude"),
+                pytest.raises(ProviderTimeoutError),
+            ):
+                provider.invoke(prompt, timeout=5)
+
+        # Provider-level log should contain truncated prompt
+        assert "prompt=" in caplog.text

--- a/tests/providers/test_tool_guard.py
+++ b/tests/providers/test_tool_guard.py
@@ -835,3 +835,78 @@ class TestToolGuardConfigDefaults:
 
         cfg = ToolGuardConfig(max_interactions_per_file_trimmed=120)
         assert cfg.get_elevated_file_cap() == 120
+
+
+class TestToolGuardConfigPerPhaseBudget:
+    """ToolGuardConfig.get_max_total_calls honors per-phase overrides."""
+
+    def test_no_override_returns_global_default(self) -> None:
+        """No per_phase config → global max_total_calls applies."""
+        from bmad_assist.core.config.models.features import ToolGuardConfig
+
+        cfg = ToolGuardConfig()
+        assert cfg.get_max_total_calls("dev_story") == 300  # default
+        assert cfg.get_max_total_calls("code_review") == 300
+
+    def test_explicit_phase_override_used(self) -> None:
+        """Per-phase override replaces global for that phase only."""
+        from bmad_assist.core.config.models.features import ToolGuardConfig
+
+        cfg = ToolGuardConfig(
+            max_total_calls=300,
+            max_total_calls_per_phase={"dev_story": 600, "create_story": 400},
+        )
+        assert cfg.get_max_total_calls("dev_story") == 600
+        assert cfg.get_max_total_calls("create_story") == 400
+        # Other phases still use global default
+        assert cfg.get_max_total_calls("code_review") == 300
+        assert cfg.get_max_total_calls("validate_story") == 300
+
+    def test_hyphen_normalized_to_underscore(self) -> None:
+        """``dev-story`` and ``dev_story`` are treated as the same phase."""
+        from bmad_assist.core.config.models.features import ToolGuardConfig
+
+        cfg = ToolGuardConfig(
+            max_total_calls_per_phase={"dev_story": 800},
+        )
+        assert cfg.get_max_total_calls("dev-story") == 800
+        assert cfg.get_max_total_calls("dev_story") == 800
+
+    def test_zero_or_negative_override_falls_back_to_default(self) -> None:
+        """Misconfigured 0 or negative → fall back to global default.
+
+        Protects the run from a yaml typo that would otherwise crash the
+        guard constructor (which requires max_total_calls >= 1).
+        """
+        from bmad_assist.core.config.models.features import ToolGuardConfig
+
+        cfg = ToolGuardConfig(
+            max_total_calls=300,
+            max_total_calls_per_phase={"dev_story": 0, "atdd": -5},
+        )
+        assert cfg.get_max_total_calls("dev_story") == 300
+        assert cfg.get_max_total_calls("atdd") == 300
+
+    def test_per_phase_budget_flows_through_to_guard_construction(
+        self,
+    ) -> None:
+        """ToolCallGuard constructed with the per-phase resolved value.
+
+        Regression guard for base.py wiring: phase-aware caller uses
+        ``get_max_total_calls(phase)`` not the raw ``max_total_calls``.
+        """
+        from bmad_assist.core.config.models.features import ToolGuardConfig
+
+        cfg = ToolGuardConfig(
+            max_total_calls=300,
+            max_total_calls_per_phase={"dev_story": 700},
+        )
+        # Simulate what base.py does
+        dev_story_cap = cfg.get_max_total_calls("dev_story")
+        review_cap = cfg.get_max_total_calls("code_review")
+
+        dev_guard = ToolCallGuard(max_total_calls=dev_story_cap)
+        review_guard = ToolCallGuard(max_total_calls=review_cap)
+
+        assert dev_guard.max_total_calls == 700
+        assert review_guard.max_total_calls == 300

--- a/tests/providers/test_tool_guard.py
+++ b/tests/providers/test_tool_guard.py
@@ -690,3 +690,148 @@ class TestPhaseEventIntegration:
             model="opus",
         )
         assert event.termination_metadata is None
+
+
+# ---------------------------------------------------------------------------
+# Elevated per-file cap for budget-trimmed files (Fix #6)
+# ---------------------------------------------------------------------------
+
+
+class TestGuardElevatedFileCap:
+    """Files in elevated_file_paths get a higher per-file interaction cap.
+
+    Trimmed files were dropped from the prompt context, so the model must
+    read them via tool calls. A flat cap punishes that legitimate use.
+    """
+
+    def test_elevated_file_uses_higher_cap(self) -> None:
+        """A file in elevated_file_paths can exceed the base cap."""
+        guard = ToolCallGuard(
+            max_total_calls=100,
+            max_interactions_per_file=3,
+            max_calls_per_minute=100,
+            elevated_file_paths={"/src/big.py"},
+            max_interactions_per_file_elevated=6,
+        )
+        # 6 reads on big.py — would exceed base cap of 3, must succeed
+        # because big.py is in the elevated set.
+        for i in range(6):
+            v = guard.check(*_make_read("/src/big.py"))
+            assert v.allowed, f"Call {i+1} on elevated file should be allowed"
+        # 7th call exceeds elevated cap — must fail
+        v = guard.check(*_make_read("/src/big.py"))
+        assert not v.allowed
+        assert "elevated" in v.reason
+        assert "would_be_7/6" in v.reason
+
+    def test_non_elevated_file_uses_base_cap(self) -> None:
+        """Non-elevated files still hit the base cap."""
+        guard = ToolCallGuard(
+            max_total_calls=100,
+            max_interactions_per_file=2,
+            max_calls_per_minute=100,
+            elevated_file_paths={"/src/elevated.py"},
+            max_interactions_per_file_elevated=10,
+        )
+        guard.check(*_make_read("/src/normal.py"))
+        guard.check(*_make_read("/src/normal.py"))
+        v = guard.check(*_make_read("/src/normal.py"))
+        assert not v.allowed
+        assert "base" in v.reason
+        assert "would_be_3/2" in v.reason
+
+    def test_auto_elevated_cap_is_double_base(self) -> None:
+        """When max_interactions_per_file_elevated is None, default = 2x base."""
+        guard = ToolCallGuard(
+            max_total_calls=100,
+            max_interactions_per_file=4,
+            max_calls_per_minute=100,
+            elevated_file_paths={"/src/auto.py"},
+            # max_interactions_per_file_elevated NOT specified
+        )
+        assert guard.max_interactions_per_file_elevated == 8
+        for _ in range(8):
+            assert guard.check(*_make_read("/src/auto.py")).allowed
+        v = guard.check(*_make_read("/src/auto.py"))
+        assert not v.allowed
+        assert "would_be_9/8" in v.reason
+
+    def test_explicit_elevated_below_base_is_clamped_up(self) -> None:
+        """Elevated cap can't be lower than base — clamped up at construction."""
+        guard = ToolCallGuard(
+            max_total_calls=100,
+            max_interactions_per_file=10,
+            max_calls_per_minute=100,
+            elevated_file_paths={"/x.py"},
+            max_interactions_per_file_elevated=2,  # absurdly low
+        )
+        # Should be silently clamped to base (10), never below.
+        assert guard.max_interactions_per_file_elevated == 10
+
+    def test_empty_elevated_set_does_not_log_elevation(self) -> None:
+        """No elevated paths → constructor logs the legacy single-cap message."""
+        # Just make sure construction succeeds and uses base cap.
+        guard = ToolCallGuard(
+            max_total_calls=100,
+            max_interactions_per_file=3,
+            max_calls_per_minute=100,
+            elevated_file_paths=set(),
+        )
+        assert guard.elevated_file_paths == set()
+        # Default elevated cap still computed but unused.
+        assert guard.max_interactions_per_file_elevated == 6
+
+    def test_elevated_paths_normalized_to_realpath(self) -> None:
+        """Elevated paths are normalized via realpath at construction.
+
+        Ensures lookups match whatever path the file tools pass in (which
+        the guard also normalizes the same way).
+        """
+        import os
+
+        guard = ToolCallGuard(
+            max_total_calls=100,
+            max_interactions_per_file=2,
+            max_calls_per_minute=100,
+            # Pass relative-style path with redundant components
+            elevated_file_paths={"/src/./../src/foo.py"},
+        )
+        # Realpath resolves to /src/foo.py
+        assert os.path.realpath("/src/foo.py") in guard.elevated_file_paths
+
+    def test_elevated_cap_validation_rejects_zero(self) -> None:
+        """max_interactions_per_file_elevated < 1 raises."""
+        with pytest.raises(ValueError, match="elevated"):
+            ToolCallGuard(
+                max_total_calls=100,
+                max_interactions_per_file=5,
+                max_calls_per_minute=100,
+                elevated_file_paths={"/x.py"},
+                max_interactions_per_file_elevated=0,
+            )
+
+
+class TestToolGuardConfigDefaults:
+    """ToolGuardConfig defaults include the new elevated-cap field."""
+
+    def test_default_max_interactions_per_file_is_40(self) -> None:
+        """Default file cap is 40 (matches code, not stale "15" docstring)."""
+        from bmad_assist.core.config.models.features import ToolGuardConfig
+
+        cfg = ToolGuardConfig()
+        assert cfg.max_interactions_per_file == 40
+
+    def test_default_trimmed_cap_is_none_meaning_auto(self) -> None:
+        """trimmed cap default is None (interpreted as 2x base via helper)."""
+        from bmad_assist.core.config.models.features import ToolGuardConfig
+
+        cfg = ToolGuardConfig()
+        assert cfg.max_interactions_per_file_trimmed is None
+        assert cfg.get_elevated_file_cap() == 80  # 2x default 40
+
+    def test_explicit_trimmed_cap_used(self) -> None:
+        """Explicit trimmed cap is returned by helper."""
+        from bmad_assist.core.config.models.features import ToolGuardConfig
+
+        cfg = ToolGuardConfig(max_interactions_per_file_trimmed=120)
+        assert cfg.get_elevated_file_cap() == 120

--- a/tests/testarch/handlers/test_base.py
+++ b/tests/testarch/handlers/test_base.py
@@ -45,14 +45,21 @@ def mock_config():
     config.testarch.knowledge = KnowledgeConfig(
         playwright_utils=True,
     )
-    
+
     # Configure providers
     config.providers = MagicMock()
     config.providers.master = MagicMock()
     config.providers.master.provider = "mock-provider"
     config.providers.master.model = "mock-model"
+    config.providers.master.display_model = "mock-model"
+    # No helper by default (testarch fallback resolver only kicks in
+    # when helper is configured and differs from master).
+    config.providers.helper = None
     config.timeout = 30
-    
+    # timeouts=None → legacy "no retry" path. Individual tests override
+    # this to exercise the retry wrapper.
+    config.timeouts = None
+
     return config
 
 
@@ -631,3 +638,217 @@ class TestExecuteWithModeCheck:
         assert result.success is True
         assert len(workflow_called) == 1
         assert result.outputs["ran"] is True
+
+# =============================================================================
+# Testarch retry + fallback (Task 14)
+# =============================================================================
+#
+# _invoke_workflow used to call provider.invoke() directly, bypassing
+# invoke_with_timeout_retry. That meant a single timeout on e.g.
+# opencode/glm-5.1 killed the phase with no retry and no fallback.
+# These tests assert the new behavior: retry N times on timeout, then
+# fall back to a secondary provider if one is resolved.
+
+
+from bmad_assist.core.exceptions import ProviderTimeoutError as _ProviderTimeoutError
+
+
+def _ok_result(stdout: str = "OK", model: str = "mock-model") -> ProviderResult:
+    return ProviderResult(
+        stdout=stdout,
+        stderr="",
+        exit_code=0,
+        duration_ms=50,
+        model=model,
+        command=("mock",),
+    )
+
+
+class TestInvokeWorkflowRetryWrapper:
+    """_invoke_workflow routes through invoke_with_timeout_retry."""
+
+    def test_no_retries_configured_is_single_attempt(
+        self, handler, mock_config
+    ) -> None:
+        """config.timeouts=None → legacy single-attempt behavior."""
+        mock_provider = MagicMock()
+        mock_provider.provider_name = "mock-provider"
+        mock_provider.invoke.return_value = _ok_result()
+        mock_compiled = MagicMock()
+        mock_compiled.context = "<compiled/>"
+
+        with patch(
+            "bmad_assist.providers.get_provider",
+            return_value=mock_provider,
+        ):
+            result = handler._invoke_workflow(mock_compiled)
+
+        assert isinstance(result, ProviderResult)
+        assert mock_provider.invoke.call_count == 1
+
+    def test_retries_on_timeout_then_succeeds(
+        self, handler, mock_config
+    ) -> None:
+        """With retries=2, a timeout + success = 2 total attempts."""
+        mock_config.timeouts = MagicMock()
+        mock_config.timeouts.get_retries.return_value = 2
+
+        mock_provider = MagicMock()
+        mock_provider.provider_name = "mock-provider"
+        # First call raises, second succeeds
+        mock_provider.invoke.side_effect = [
+            _ProviderTimeoutError("slow"),
+            _ok_result(),
+        ]
+        mock_compiled = MagicMock()
+        mock_compiled.context = "<compiled/>"
+
+        with patch(
+            "bmad_assist.providers.get_provider",
+            return_value=mock_provider,
+        ):
+            result = handler._invoke_workflow(mock_compiled)
+
+        assert isinstance(result, ProviderResult)
+        assert mock_provider.invoke.call_count == 2
+
+    def test_retries_exhausted_without_fallback_returns_fail(
+        self, handler, mock_config
+    ) -> None:
+        """Retries exhausted + no fallback → PhaseResult.fail with timeout message."""
+        mock_config.timeouts = MagicMock()
+        mock_config.timeouts.get_retries.return_value = 1
+
+        mock_provider = MagicMock()
+        mock_provider.provider_name = "mock-provider"
+        mock_provider.invoke.side_effect = _ProviderTimeoutError("stuck")
+        mock_compiled = MagicMock()
+        mock_compiled.context = "<compiled/>"
+
+        with patch(
+            "bmad_assist.providers.get_provider",
+            return_value=mock_provider,
+        ):
+            result = handler._invoke_workflow(mock_compiled)
+
+        assert isinstance(result, PhaseResult)
+        assert result.success is False
+        # Error message surfaces the phase name + timeout context
+        assert "test_phase" in (result.error or "") or "timeout" in (result.error or "").lower()
+        # Primary tried retries+1 times (1 retry = 2 attempts)
+        assert mock_provider.invoke.call_count == 2
+
+
+class TestInvokeWorkflowFallbackResolution:
+    """_resolve_testarch_fallback picks the right fallback for each primary."""
+
+    def test_claude_primary_falls_back_to_subprocess(
+        self, handler, mock_config
+    ) -> None:
+        """primary='claude' → ClaudeSubprocessProvider fallback (legacy)."""
+        mock_config.providers.master.provider = "claude"
+        fn, model, display = handler._resolve_testarch_fallback("claude")
+        assert fn is not None
+        # Claude fallback reuses the primary model (subprocess path).
+        assert model is None
+        assert display is None
+        # The returned callable is a ClaudeSubprocessProvider.invoke bound method.
+        assert "ClaudeSubprocess" in type(fn.__self__).__name__  # type: ignore[attr-defined]
+
+    def test_helper_fallback_when_configured_and_different(
+        self, handler, mock_config
+    ) -> None:
+        """Non-claude primary + helper configured → helper as fallback."""
+        mock_config.providers.master.provider = "opencode"
+        mock_config.providers.helper = MagicMock()
+        mock_config.providers.helper.provider = "claude"
+        mock_config.providers.helper.model = "haiku"
+        mock_config.providers.helper.display_model = "haiku"
+
+        helper_provider = MagicMock()
+        helper_provider.invoke = MagicMock()
+
+        with patch(
+            "bmad_assist.providers.get_provider",
+            return_value=helper_provider,
+        ):
+            fn, model, display = handler._resolve_testarch_fallback("opencode")
+
+        assert fn is helper_provider.invoke
+        assert model == "haiku"
+        assert display == "haiku"
+
+    def test_no_fallback_when_helper_provider_matches_primary(
+        self, handler, mock_config
+    ) -> None:
+        """If helper uses the same provider family as primary → no fallback."""
+        mock_config.providers.master.provider = "opencode"
+        mock_config.providers.helper = MagicMock()
+        mock_config.providers.helper.provider = "opencode"
+        mock_config.providers.helper.model = "something-else"
+
+        fn, model, display = handler._resolve_testarch_fallback("opencode")
+
+        assert fn is None
+        assert model is None
+        assert display is None
+
+    def test_no_fallback_when_helper_unset(self, handler, mock_config) -> None:
+        """Helper is None → no fallback."""
+        mock_config.providers.master.provider = "opencode"
+        mock_config.providers.helper = None
+        fn, model, display = handler._resolve_testarch_fallback("opencode")
+        assert (fn, model, display) == (None, None, None)
+
+
+class TestInvokeWorkflowHelperFallbackEndToEnd:
+    """Primary timeout exhausted → helper fallback actually invoked."""
+
+    def test_primary_timeout_triggers_helper_fallback(
+        self, handler, mock_config
+    ) -> None:
+        """When primary exhausts retries, helper is invoked with its own model."""
+        mock_config.timeouts = MagicMock()
+        mock_config.timeouts.get_retries.return_value = 1
+        # Set up helper
+        mock_config.providers.master.provider = "opencode"
+        mock_config.providers.master.model = "glm-5.1"
+        mock_config.providers.master.display_model = "glm-5.1"
+        mock_config.providers.helper = MagicMock()
+        mock_config.providers.helper.provider = "claude"
+        mock_config.providers.helper.model = "haiku"
+        mock_config.providers.helper.display_model = "haiku"
+
+        primary = MagicMock()
+        primary.provider_name = "opencode"
+        primary.invoke.side_effect = _ProviderTimeoutError("stuck")
+
+        helper = MagicMock()
+        helper.invoke.return_value = _ok_result(stdout="from helper", model="haiku")
+
+        def _get_provider(name: str):
+            if name == "opencode":
+                return primary
+            if name == "claude":
+                return helper
+            raise AssertionError(f"unexpected provider {name}")
+
+        mock_compiled = MagicMock()
+        mock_compiled.context = "<compiled/>"
+
+        with patch(
+            "bmad_assist.providers.get_provider",
+            side_effect=_get_provider,
+        ):
+            result = handler._invoke_workflow(mock_compiled)
+
+        # Primary was tried (retries+1 = 2 attempts), fallback took over.
+        assert primary.invoke.call_count == 2
+        assert helper.invoke.call_count == 1
+        # Helper was called with its own model, not the primary model.
+        helper_call_kwargs = helper.invoke.call_args.kwargs
+        assert helper_call_kwargs["model"] == "haiku"
+        assert helper_call_kwargs["display_model"] == "haiku"
+        # Result came from helper
+        assert isinstance(result, ProviderResult)
+        assert result.stdout == "from helper"

--- a/tests/testarch/test_eligibility.py
+++ b/tests/testarch/test_eligibility.py
@@ -1214,6 +1214,7 @@ class TestProviderInvocation:
         mock_helper_config = MagicMock()
         mock_helper_config.providers.helper.provider = "claude"
         mock_helper_config.providers.helper.model = "haiku"
+        mock_helper_config.providers.helper.timeout = 120
 
         with (
             patch(
@@ -1230,7 +1231,7 @@ class TestProviderInvocation:
         # Verify invoke parameters
         invoke_call = mock_provider.invoke.call_args
         assert invoke_call.kwargs["model"] == "haiku"
-        assert invoke_call.kwargs["timeout"] == 60
+        assert invoke_call.kwargs["timeout"] == 120
         assert invoke_call.kwargs["disable_tools"] is True
         assert invoke_call.kwargs["no_cache"] is True
 
@@ -1262,6 +1263,7 @@ class TestCombinedReasoning:
         mock_helper_config = MagicMock()
         mock_helper_config.providers.helper.provider = "claude"
         mock_helper_config.providers.helper.model = "haiku"
+        mock_helper_config.providers.helper.timeout = 120
 
         with (
             patch("bmad_assist.providers.registry.get_provider", return_value=mock_provider),

--- a/tests/validation/test_evidence_score.py
+++ b/tests/validation/test_evidence_score.py
@@ -584,3 +584,111 @@ class TestAllValidatorsFailedError:
         """Test error message content."""
         error = AllValidatorsFailedError("All validators failed")
         assert "All validators failed" in str(error)
+
+
+# =============================================================================
+# Score-Card Fraction Parsing (Fix #5)
+# =============================================================================
+#
+# Real reports the parser used to drop on the floor. Each test recreates
+# the failing format from a real bmad-assist run and asserts the parser
+# now derives a sensible Evidence Score from the score-card fraction
+# instead of returning None.
+
+
+class TestEvidenceScoreCardFraction:
+    """Parser must extract score from real ``## Evidence Score [Card]`` reports."""
+
+    def test_parses_total_fraction_from_score_card(self) -> None:
+        """Validation report with ``## Evidence Score Card`` and Total row."""
+        # Shape from validation-10-7-c report (one of the failing previews
+        # quoted in the run logs). 43/55 → 21.8% missed → score ~2.2 → PASS.
+        content = """\
+## Evidence Score Card
+
+| Category | Score | Max | Notes |
+|----------|-------|-----|-------|
+| INVEST Compliance | 14/18 | 18 | 2 criteria have IMPORTANT gaps |
+| AC Completeness | 7/9 | 9 | AC3 ambiguity |
+| Hidden Dependencies | 5/6 | 6 | jiff API |
+| Estimation Realism | 3/4 | 4 | Snapshot cascade |
+| Technical Alignment | 5/6 | 6 | Duplicate type models |
+| Disaster Prevention | 9/12 | 12 | 3 issues |
+| **Total** | **43/55** | **55** | |
+
+**Evidence Score:** 43/55 → **78%**
+**Verdict:** ⚠️ **CONDITIONAL PASS**
+"""
+        report = parse_evidence_findings(content, "validator-c")
+        assert report is not None, "should not drop a report with a score-card"
+        # 43/55 → 12 missed / 55 = 0.218 * 10 ≈ 2.2
+        assert report.total_score == pytest.approx(2.2, abs=0.1)
+        assert report.verdict == Verdict.PASS
+
+    def test_parses_total_fraction_from_evidence_score_heading(self) -> None:
+        """Code-review report with ``## Evidence Score`` and ``**Total: 58/100**``."""
+        # Shape from code-review-10-4d-b. 58/100 → 42% missed → score ~4.2 →
+        # MAJOR_REWORK.
+        content = """\
+## Evidence Score
+
+| Criterion | Weight | Score | Notes |
+|-----------|--------|-------|-------|
+| All ACs have test coverage | 20 | 14/20 | Acceptance tests for AC1-AC6 |
+| Code compiles | 15 | 15/15 | |
+| Documentation | 10 | 0/10 | Stale docs |
+
+**Total: 58/100**
+"""
+        report = parse_evidence_findings(content, "validator-b")
+        assert report is not None
+        assert report.total_score == pytest.approx(4.2, abs=0.1)
+        assert report.verdict == Verdict.MAJOR_REWORK
+
+    def test_inline_bold_evidence_score_is_parsed(self) -> None:
+        """``**Evidence Score:** 3.5`` (bold-wrapped inline) should parse."""
+        content = """\
+## Summary
+
+**Evidence Score:** 3.5
+**Verdict:** PASS
+"""
+        report = parse_evidence_findings(content, "validator-a")
+        assert report is not None
+        assert report.total_score == pytest.approx(3.5, abs=0.05)
+
+    def test_score_card_without_heading_not_misinterpreted(self) -> None:
+        """A bare ``Total: 5/10`` line without an Evidence Score heading.
+
+        Must NOT be parsed as Evidence Score — protects against false
+        positives matching arbitrary "Total: X/Y" lines (e.g. test
+        coverage tables).
+        """
+        content = """\
+## Test Pass Rate
+
+| Suite | Pass / Total |
+|-------|--------------|
+| unit  | 5/10         |
+
+**Total: 5/10**
+"""
+        report = parse_evidence_findings(content, "validator-x")
+        # No findings, no clean passes, no Evidence Score heading → drop.
+        assert report is None
+
+    def test_perfect_score_card_yields_pass(self) -> None:
+        """100% score-card → 0.0 → EXCELLENT/PASS verdict band."""
+        content = """\
+## Evidence Score Card
+
+| Category | Score | Max |
+|----------|-------|-----|
+| Coverage | 10/10 | 10 |
+| **Total** | **10/10** | **10** |
+"""
+        report = parse_evidence_findings(content, "validator-z")
+        assert report is not None
+        assert report.total_score == pytest.approx(0.0, abs=0.05)
+        # Score 0.0 falls between -3 and 4 → PASS verdict band
+        assert report.verdict == Verdict.PASS

--- a/tests/validation/test_evidence_score.py
+++ b/tests/validation/test_evidence_score.py
@@ -692,3 +692,140 @@ class TestEvidenceScoreCardFraction:
         assert report.total_score == pytest.approx(0.0, abs=0.05)
         # Score 0.0 falls between -3 and 4 → PASS verdict band
         assert report.verdict == Verdict.PASS
+
+
+# =============================================================================
+# Numbered finding headings (validator A from 10.8 run)
+# =============================================================================
+#
+# Some adversarial validation reports list each finding as its own
+# numbered subheading: ``### CRITICAL-1: description``. Section-header
+# parser missed these because it only matches headings without the
+# numbered suffix (CRITICAL, not CRITICAL-1) and then scans for bullets.
+
+
+class TestParseNumberedFindingHeadings:
+    """Parser must accept ``### SEVERITY-N: description`` heading style."""
+
+    def test_parses_critical_important_minor_numbered_headings(self) -> None:
+        """Real shape from validation-10-8-a: numbered subheadings under
+        ``## 3. Critical Issues`` etc."""
+        content = """\
+## 3. Critical Issues
+
+### CRITICAL-1: Missing `active_instance_index()` in CoreConnection Trait
+
+Some prose body explaining the issue.
+
+### CRITICAL-2: `unwrap()` on RwLock Violates Project Rule — 11 Instances
+
+More prose.
+
+## 4. Important Issues
+
+### IMPORTANT-1: Story Too Large for Single Sprint
+
+Body.
+
+### IMPORTANT-2: ConnectionManager File Placement Contradicts Architecture
+
+Body.
+
+## 5. Minor Issues
+
+### MINOR-1: AC1 vs Out of Scope Contradiction
+"""
+        report = parse_evidence_findings(content, "validator-a")
+        assert report is not None, "should not drop a numbered-finding report"
+        # 2 CRITICAL + 2 IMPORTANT + 1 MINOR = 5 findings
+        assert len(report.findings) == 5
+        criticals = [f for f in report.findings if f.severity == Severity.CRITICAL]
+        importants = [f for f in report.findings if f.severity == Severity.IMPORTANT]
+        minors = [f for f in report.findings if f.severity == Severity.MINOR]
+        assert len(criticals) == 2
+        assert len(importants) == 2
+        assert len(minors) == 1
+        # Bmad weights: 2*3 + 2*1 + 1*0.3 = 8.3 → REJECT (≥6)
+        assert report.total_score == pytest.approx(8.3, abs=0.05)
+        assert report.verdict == Verdict.REJECT
+
+    def test_numbered_heading_description_extracted(self) -> None:
+        """The description from each heading is captured."""
+        content = """\
+### CRITICAL-1: Buffer overflow in parser
+Body line.
+
+### IMPORTANT-2: API rate limit not enforced
+Body line.
+"""
+        report = parse_evidence_findings(content, "validator-x")
+        assert report is not None
+        descriptions = [f.description for f in report.findings]
+        assert "Buffer overflow in parser" in descriptions
+        assert "API rate limit not enforced" in descriptions
+
+    def test_numbered_heading_runs_before_section_header(self) -> None:
+        """Numbered finding parser must take precedence over section header.
+
+        A report with both ``## CRITICAL Findings`` and individual
+        ``### CRITICAL-N`` headings must produce one finding per
+        numbered heading, NOT use section-header bullet extraction.
+        """
+        content = """\
+## CRITICAL Findings
+
+### CRITICAL-1: First issue
+### CRITICAL-2: Second issue
+### CRITICAL-3: Third issue
+"""
+        report = parse_evidence_findings(content, "validator-y")
+        assert report is not None
+        # Should be 3 findings (one per numbered heading), not zero or 1
+        assert len(report.findings) == 3
+        assert all(f.severity == Severity.CRITICAL for f in report.findings)
+
+    def test_high_medium_low_aliases_in_numbered_headings(self) -> None:
+        """Aliases (HIGH→CRITICAL, MEDIUM→IMPORTANT, LOW→MINOR) work in numbered form."""
+        content = """\
+### HIGH-1: Critical aliased
+### MEDIUM-1: Important aliased
+### LOW-1: Minor aliased
+"""
+        report = parse_evidence_findings(content, "validator-z")
+        assert report is not None
+        assert len(report.findings) == 3
+        sevs = sorted(f.severity for f in report.findings)
+        assert Severity.CRITICAL in sevs
+        assert Severity.IMPORTANT in sevs
+        assert Severity.MINOR in sevs
+
+    def test_numbered_heading_skipped_when_table_findings_present(self) -> None:
+        """If a structured finding table is present, that wins over numbered headings."""
+        content = """\
+| 🔴 CRITICAL | Buffer overflow | parser.c:42 | +3 |
+
+### MINOR-1: Should not be counted (table strategy already produced findings)
+"""
+        report = parse_evidence_findings(content, "validator-w")
+        assert report is not None
+        # Only the table finding, not the numbered MINOR.
+        assert len(report.findings) == 1
+        assert report.findings[0].severity == Severity.CRITICAL
+
+
+class TestEvidenceScoreHeadingAcceptsNumberedPrefix:
+    """The score-card heading guard must accept numbered section prefixes."""
+
+    def test_numbered_prefix_in_heading_recognized(self) -> None:
+        """``## 11. Evidence Score`` triggers the score-card fraction strategy."""
+        content = """\
+## 11. Evidence Score
+
+| Category | Score | Max | Notes |
+|----------|-------|-----|-------|
+| INVEST | 14/18 | 18 | |
+| **Total** | **43/55** | **55** | |
+"""
+        report = parse_evidence_findings(content, "validator-num")
+        assert report is not None
+        assert report.total_score == pytest.approx(2.2, abs=0.1)

--- a/tests/validation/test_orchestrator.py
+++ b/tests/validation/test_orchestrator.py
@@ -1279,3 +1279,154 @@ class TestStory22_8SessionIdInValidationReports:
             assert found_session_id, (
                 f"Expected session_id={result.session_id} in validation report frontmatter"
             )
+
+
+# ============================================================================
+# Provider-error log cleanliness (Task 16)
+# ============================================================================
+#
+# _invoke_validator used to log full tracebacks on ANY exception, including
+# expected provider-layer failures like auth errors or quota exhaustion.
+# The fix splits the handler so ProviderError → clean message, other
+# exceptions → keep the traceback (those indicate actual bugs).
+
+
+import logging as _task16_logging  # noqa: E402
+
+from bmad_assist.core.exceptions import (  # noqa: E402
+    ProviderError,
+    ProviderExitCodeError,
+    ProviderTimeoutError,
+)
+from bmad_assist.providers.base import ExitStatus  # noqa: E402
+from bmad_assist.validation.orchestrator import _invoke_validator  # noqa: E402
+
+
+class TestInvokeValidatorErrorLogging:
+    """_invoke_validator logs provider errors cleanly, other errors with traceback."""
+
+    @pytest.fixture
+    def mock_provider(self) -> MagicMock:
+        provider = MagicMock()
+        provider.provider_name = "mock-provider"
+        return provider
+
+    async def _invoke(self, provider: MagicMock) -> tuple:
+        return await _invoke_validator(
+            provider=provider,
+            prompt="<compiled/>",
+            timeout=60,
+            provider_id="mock-validator",
+            model="mock-model",
+            timeout_retries=None,
+            display_model="mock-display",
+        )
+
+    @pytest.mark.asyncio
+    async def test_provider_exit_code_error_logged_without_traceback(
+        self,
+        mock_provider: MagicMock,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Auth errors (ProviderExitCodeError) log clean single-line warning."""
+        mock_provider.invoke.side_effect = ProviderExitCodeError(
+            "Cursor Agent CLI failed with exit code 1: "
+            "Error: Authentication required. Please run 'agent login' first.",
+            exit_code=1,
+            exit_status=ExitStatus.ERROR,
+            stderr="Authentication required",
+            stdout="",
+            command=("cursor-agent",),
+        )
+
+        with caplog.at_level(
+            _task16_logging.WARNING, logger="bmad_assist.validation.orchestrator"
+        ):
+            provider_id, output, metrics, error_msg = await self._invoke(mock_provider)
+
+        assert provider_id == "mock-validator"
+        assert output is None
+        assert metrics is None
+        assert error_msg is not None
+        assert "Authentication required" in error_msg
+        warnings = [
+            r
+            for r in caplog.records
+            if r.levelname == "WARNING" and "mock-validator failed" in r.getMessage()
+        ]
+        assert warnings, "expected 'Validator X failed' warning"
+        assert all(
+            r.exc_info is None for r in warnings
+        ), "ProviderError should log WITHOUT traceback"
+
+    @pytest.mark.asyncio
+    async def test_provider_timeout_error_logged_without_traceback(
+        self,
+        mock_provider: MagicMock,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        mock_provider.invoke.side_effect = ProviderTimeoutError(
+            "OpenCode CLI timeout after 1800s: ..."
+        )
+
+        with caplog.at_level(
+            _task16_logging.WARNING, logger="bmad_assist.validation.orchestrator"
+        ):
+            _, _, _, error_msg = await self._invoke(mock_provider)
+
+        assert error_msg is not None
+        warnings = [
+            r
+            for r in caplog.records
+            if r.levelname == "WARNING" and "failed" in r.getMessage()
+        ]
+        assert warnings
+        assert all(r.exc_info is None for r in warnings)
+
+    @pytest.mark.asyncio
+    async def test_provider_error_base_class_logged_without_traceback(
+        self,
+        mock_provider: MagicMock,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        mock_provider.invoke.side_effect = ProviderError("Network disconnected")
+
+        with caplog.at_level(
+            _task16_logging.WARNING, logger="bmad_assist.validation.orchestrator"
+        ):
+            _, _, _, error_msg = await self._invoke(mock_provider)
+
+        assert error_msg is not None
+        assert "Network disconnected" in error_msg
+        warnings = [
+            r
+            for r in caplog.records
+            if r.levelname == "WARNING" and "failed" in r.getMessage()
+        ]
+        assert warnings
+        assert all(r.exc_info is None for r in warnings)
+
+    @pytest.mark.asyncio
+    async def test_unexpected_exception_keeps_traceback(
+        self,
+        mock_provider: MagicMock,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Non-Provider exceptions (bugs) must still log with traceback."""
+        mock_provider.invoke.side_effect = RuntimeError("surprise bug")
+
+        with caplog.at_level(
+            _task16_logging.WARNING, logger="bmad_assist.validation.orchestrator"
+        ):
+            _, _, _, error_msg = await self._invoke(mock_provider)
+
+        assert error_msg is not None
+        warnings = [
+            r
+            for r in caplog.records
+            if r.levelname == "WARNING" and "failed" in r.getMessage()
+        ]
+        assert warnings
+        assert any(
+            r.exc_info is not None for r in warnings
+        ), "RuntimeError should log WITH traceback"

--- a/tests/validation/test_timeout_scaling.py
+++ b/tests/validation/test_timeout_scaling.py
@@ -1,0 +1,61 @@
+"""Tests for validation timeout scaling (Fix #7)."""
+
+
+class TestTimeoutScaling:
+    """Test timeout proportional scaling logic."""
+
+    def test_small_prompt_uses_base_timeout(self) -> None:
+        """Prompt under reference size (100K chars) keeps base timeout."""
+        base_timeout = 600
+        prompt_chars = 50_000
+        reference = 100_000
+        if prompt_chars > reference:
+            scaled = int(base_timeout * (prompt_chars / reference))
+        else:
+            scaled = base_timeout
+        assert scaled == 600
+
+    def test_large_prompt_scales_timeout(self) -> None:
+        """200K char prompt doubles the timeout."""
+        base_timeout = 600
+        prompt_chars = 200_000
+        reference = 100_000
+        scaled = int(base_timeout * (prompt_chars / reference))
+        assert scaled == 1200
+
+    def test_very_large_prompt_scales_proportionally(self) -> None:
+        """400K char prompt quadruples the timeout."""
+        base_timeout = 600
+        prompt_chars = 400_000
+        reference = 100_000
+        scaled = int(base_timeout * (prompt_chars / reference))
+        assert scaled == 2400
+
+    def test_exactly_reference_size_no_change(self) -> None:
+        """100K chars keeps base timeout."""
+        base_timeout = 600
+        prompt_chars = 100_000
+        reference = 100_000
+        # At exactly reference, no scaling needed
+        if prompt_chars > reference:
+            scaled = int(base_timeout * (prompt_chars / reference))
+        else:
+            scaled = base_timeout
+        assert scaled == 600
+
+    def test_scaling_uses_integer(self) -> None:
+        """Result is always int."""
+        base_timeout = 600
+        prompt_chars = 150_000
+        reference = 100_000
+        scaled = int(base_timeout * (prompt_chars / reference))
+        assert isinstance(scaled, int)
+        assert scaled == 900
+
+    def test_455k_prompt_with_600s_base(self) -> None:
+        """Real-world case: 455K prompt with 600s base -> 2730s."""
+        base_timeout = 600
+        prompt_chars = 455_000
+        reference = 100_000
+        scaled = int(base_timeout * (prompt_chars / reference))
+        assert scaled == 2730


### PR DESCRIPTION
## Summary

- **Fix 10 run warnings/errors** found during long `bmad-assist run` sessions: fallback timeout inheritance, ToolCallGuard file cap, prompt budget enforcement, extraction warnings, timeout error messages, token estimation, timeout scaling, and debug logging
- **Fix sub-story parsing** — 27 stories silently dropped across 8 epics because regex only matched numeric IDs. Now handles `3a`, `3a-ii`, `4b` etc. across all phases (parser, state reader, sprint scanner, retrospective, variables, benchmarking, dashboard)
- **Add `--backfill` CLI flag** — after completing current story, implements all missed/skipped stories before the current position, then resumes normal forward execution. Uses persistent frontier, skips epic teardown/retrospective during backfill. Respects `deferred` status in sprint-status.
- **Configurable helper provider timeout** — `providers.helper.timeout` in bmad-assist.yaml (default 120s, was hardcoded at 60s)
- **Fix Starlette 1.0 compatibility** — replace deprecated `on_startup`/`on_shutdown` with `lifespan` context manager, fixing 96 dashboard test failures

## Key changes

### Run warnings/errors (commit 1)
- Fallback provider gets 1.5x timeout instead of inheriting primary's (critical fix for 1h+ timeout chains)
- ToolCallGuard `max_interactions_per_file` raised from 25 → 40
- Post-compilation prompt budget enforcement trims lowest-priority source files
- Extraction warnings distinguish ToolCallGuard truncation from LLM format issues
- Timeout errors no longer leak prompt content through retry chain
- Token estimate uses `len(prompt)//4` instead of `compiled.token_estimate * 2`
- Validator timeout scales proportionally to prompt size (>100K chars)

### Sub-story parsing (commits 2-3, 6-7)
- `STORY_HEADER_PATTERN` regex now matches `10.3a`, `10.3a-ii`, `10.4b`
- Natural sort key: `3 < 3a < 3a-ii < 3a-iii < 3b < 4`
- Sprint-status key parser handles all sub-story formats
- Safe `int()` extraction at 5 crash sites; preserve full sub-story IDs in validators
- All artifact scanner patterns use `\d+(?:[a-z](?:-[ivx]{2,})*)?` to avoid greedy slug matching
- Type signatures `story_num: int` → `int | str` across 16+ files (including mypy-checked paths)

### --backfill mode (commits 2, 5)
- New `--backfill` CLI flag on `bmad-assist run`
- **Persistent frontier**: set once when backfill activates, stays fixed throughout the pass
- Skips epic teardown/retrospective/prompts during backfill (no stopping between backfilled epics)
- Normal epic-boundary behavior resumes after backfill complete
- Stays on current git branch during backfill (no branch switching)
- Respects `deferred`/`cancelled`/`skipped` status in sprint-status

### Helper timeout config (commit 4)
- New `providers.helper.timeout` field (default 120s, min 10s)
- Replaces hardcoded 60s in ATDD eligibility and 120s in strategic context compression

### Starlette 1.0 compatibility (commit 5)
- Replace deprecated `on_startup`/`on_shutdown` kwargs with `lifespan` async context manager
- Fixes 96 dashboard test failures caused by Starlette 1.0.0 removing the old API

## Test plan

- [x] 46 new tests for run warning fixes (retry, extraction, budget, guard, timeout, scaling)
- [x] 17 new tests for sub-story parsing (regex, sort key, sprint-status, flatten)
- [x] 13 new tests for backfill mode (gap detection, cross-epic, exclusions, frontier persistence)
- [x] 4 new tests for helper timeout config
- [x] Updated existing tests for prompt leak fix and eligibility timeout
- [x] **CI: all tests pass, all type checks pass, all lint passes** ✅